### PR TITLE
feat: Compute Image Trim in Isolate and show Loading Screen

### DIFF
--- a/apps/flites/lib/types/flites_image.dart
+++ b/apps/flites/lib/types/flites_image.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
+
+import 'package:flites/states/canvas_controller.dart';
 import 'package:flites/utils/image_processing_utils.dart';
 import 'package:flites/utils/image_utils.dart';
-import 'package:flites/states/canvas_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
 import '../states/open_project.dart';
 
 /// A working file type we use to work with this image
@@ -83,7 +85,7 @@ class FlitesImage {
   }
 
   void trimImage() async {
-    image = await ImageProcessingUtils.rotateImage(image, rotation);
+    image = await ImageProcessingUtils.rotateInIsolates(image, rotation);
 
     rotation = 0;
   }

--- a/apps/flites/lib/utils/image_processing_utils.dart
+++ b/apps/flites/lib/utils/image_processing_utils.dart
@@ -1,32 +1,65 @@
 import 'dart:math';
-import 'dart:typed_data';
+import 'package:flites/widgets/loading_overlay/loading_overlay.dart';
+import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 
 /// A utility class for working with images.
 /// Holds methods for rotating images.
 class ImageProcessingUtils {
-  static Future<Uint8List> rotateImage(
-      Uint8List pngBytes, double angleRadians) async {
-    final originalImage = img.decodePng(pngBytes);
+  /// Rotates an image by the given angle in radians.
+  /// The computation of each step is done in an isolate.
+  static Future<Uint8List> rotateInIsolates(
+    Uint8List pngBytes,
+    double angleRadians,
+  ) async {
+    try {
+      // Show loading overlay while processing
+      showLoadingOverlay.value = true;
 
-    if (originalImage == null) {
-      throw Exception('Unable to decode PNG');
+      final originalImage = await compute(img.decodePng, pngBytes);
+
+      if (originalImage == null) {
+        throw Exception('Unable to decode PNG');
+      }
+
+      final diagonal =
+          sqrt(pow(originalImage.width, 2) + pow(originalImage.height, 2))
+              .ceil();
+
+      final canvas = img.Image(
+        width: diagonal,
+        height: diagonal,
+        numChannels: 4,
+        format: img.Format.uint8,
+      );
+
+      final rotatedImage = await compute(_rotateImageWithArgs, {
+        'image': originalImage,
+        'angle': angleRadians * 180 / pi,
+      });
+
+      final compositeImage = await compute(_compositeImagesWithArgs, {
+        'canvas': canvas,
+        'rotatedImage': rotatedImage,
+      });
+
+      final trimmedImage = await compute(img.trim, compositeImage);
+      final encodedPngImage = await compute(img.encodePng, trimmedImage);
+
+      return encodedPngImage;
+    } catch (e) {
+      debugPrint('Rotation error: $e');
+      rethrow;
+    } finally {
+      showLoadingOverlay.value = false;
     }
+  }
 
-    final longestSide = max(originalImage.width, originalImage.height) * 2;
+  static img.Image _rotateImageWithArgs(Map<String, dynamic> args) {
+    return img.copyRotate(args['image'], angle: args['angle']);
+  }
 
-    final canvas = img.Image(
-      width: longestSide,
-      height: longestSide,
-      numChannels: 4,
-      format: img.Format.uint8,
-    );
-
-    final rotatedImage =
-        img.copyRotate(originalImage, angle: angleRadians * 180 / pi);
-    final composite = img.compositeImage(canvas, rotatedImage);
-    final trimmedImage = img.trim(composite);
-
-    return Uint8List.fromList(img.encodePng(trimmedImage));
+  static img.Image _compositeImagesWithArgs(Map<String, img.Image> args) {
+    return img.compositeImage(args['canvas']!, args['rotatedImage']!);
   }
 }

--- a/apps/flites/lib/widgets/image_editor/image_editor.dart
+++ b/apps/flites/lib/widgets/image_editor/image_editor.dart
@@ -4,6 +4,7 @@ import 'package:flites/states/key_events.dart';
 import 'package:flites/states/selected_images_controller.dart';
 import 'package:flites/states/tool_controller.dart';
 import 'package:flites/widgets/canvas_controls/canvas_controls.dart';
+import 'package:flites/widgets/loading_overlay/loading_overlay.dart';
 import 'package:flites/widgets/rotation/rotation_wrapper.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -261,6 +262,8 @@ class _ImageEditorState extends State<ImageEditor> {
                           );
                         },
                       ),
+
+                    if (showLoadingOverlay.value) const LoadingOverlay(),
                   ],
                 ),
               ),

--- a/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
+++ b/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:signals/signals_flutter.dart';
+
+final showLoadingOverlay = signal(false);
+
+class LoadingOverlay extends StatelessWidget {
+  const LoadingOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Container(
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
+          child: const Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('Please wait while we process your image'),
+                SizedBox(height: 16),
+                SizedBox(
+                  width: 300,
+                  child: LinearProgressIndicator(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/flites/pubspec.lock
+++ b/apps/flites/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cross_file:
     dependency: transitive
     description:
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.6"
+  flutter_isolate:
+    dependency: "direct main"
+    description:
+      name: flutter_isolate
+      sha256: "36a84e1a22371d8092ea2121145b330c24fb272acb951fb30c60ba44926b8fb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -244,18 +252,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -412,7 +420,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -433,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -521,10 +529,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:

--- a/apps/flites/pubspec.yaml
+++ b/apps/flites/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   file_saver: ^0.2.14
   flutter_box_transform: ^0.4.6
   file_picker: ^8.1.4
+  flutter_isolate: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->
Trimming the image after rotation is a quite expensive computation that freezes the screen.

To enhance UX we compute the trimming in another thread via compute() and show a loading overlay


## Description

<!--- Describe your changes in detail -->

Installed `flutter_isolates`.

wrapped expensive computations with `await compute` like:

```dart
final compositeImage = await compute(_compositeImagesWithArgs, {
  'canvas': canvas,
  'rotatedImage': rotatedImage,
});

final trimmedImage = await compute(img.trim, compositeImage);
```

show a loading screen while processing 

<img src="https://github.com/user-attachments/assets/df8e7e05-ee51-4c22-a6a8-51336162ce3f" width="50%"/>

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
