### PR TITLE
fix: Sub Optimal Line Break in "Playback Speed"

### DIFF
--- a/apps/flites/lib/widgets/player/player.dart
+++ b/apps/flites/lib/widgets/player/player.dart
@@ -84,10 +84,10 @@ class _PlayerControlsState extends State<PlayerControls> {
               const SizedBox(width: 32),
               Flexible(
                 child: Text(
-                  'Playback Speed',
+                  'Player Speed',
                   style: TextStyle(
                     fontSize: 16,
-                    color: context.colors.surfaceContainerHighest,
+                    color: context.colors.outline,
                   ),
                 ),
               ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

This PR tries to close #18.

To avoid a bad line break I changed the `string` from "Playback Speed" to "Player Speed" and also changed the color to be a bit lighter. 



![Selection_004](https://github.com/user-attachments/assets/532afd6f-e065-4bf0-b941-2b94cceeee45)



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
