### PR TITLE
feat: Allow Opening Overlaid Gifs

### DIFF
--- a/apps/flites/lib/utils/image_picker.dart
+++ b/apps/flites/lib/utils/image_picker.dart
@@ -3,6 +3,7 @@ import 'package:flites/constants/image_constants.dart';
 import 'package:flites/types/flites_image.dart';
 import 'package:flites/utils/image_utils.dart';
 import 'package:flites/utils/png_utils.dart';
+import 'package:image/image.dart' as img;
 
 class ImagePickerService {
   Future<List<FlitesImage>> pickAndProcessImages() async {
@@ -10,37 +11,90 @@ class ImagePickerService {
       allowMultiple: true,
       withData: true,
       type: FileType.custom,
-      allowedExtensions: ['png'],
+      allowedExtensions: ['png', 'gif'],
     );
 
-    // If no files were picked, return empty list
-    if (result == null) {
-      return [];
+    if (result == null) return [];
+
+    List<RawImageAndName> imagesAndNames = [];
+    for (final file in result.files) {
+      final images = await _processFile(file);
+      imagesAndNames.addAll(images);
     }
 
-    final imagesAndNames = (await Future.wait(
-            result.files.map(ImageUtils.rawImageFroMPlatformFile)))
-        .whereType<RawImageAndName>()
-        .where((e) => e.image != null && PngUtils.isPng(e.image!))
-        .toList();
+    if (imagesAndNames.isEmpty) return [];
 
-    // If no valid images were found, return empty list
-    if (imagesAndNames.isEmpty) {
-      return [];
+    return _processAndScaleImages(imagesAndNames);
+  }
+
+  Future<List<RawImageAndName>> _processFile(PlatformFile file) async {
+    switch (file.extension?.toLowerCase()) {
+      case 'gif':
+        return _processGifFile(file);
+      case 'png':
+        return _processPngFile(file);
+      default:
+        return [];
     }
+  }
 
+  Future<List<RawImageAndName>> _processGifFile(PlatformFile file) async {
+    final List<RawImageAndName> images = [];
+    final gifDecoder = img.GifDecoder();
+    final decodedGif = gifDecoder.decode(file.bytes!);
+
+    if (decodedGif != null) {
+      // This starts at 1 because we want to skip the composite frame
+      for (int i = 1; i < decodedGif.numFrames; i++) {
+        final frame = decodedGif.getFrame(i);
+        final staticFrame = img.Image.from(frame);
+        final frameBytes = img.encodePng(staticFrame);
+        images.add(
+          RawImageAndName(
+            image: frameBytes,
+            name: '${file.name.replaceAll('.gif', '')}_frame_$i.png',
+          ),
+        );
+      }
+    }
+    return images;
+  }
+
+  Future<List<RawImageAndName>> _processPngFile(PlatformFile file) async {
+    final rawImage = await ImageUtils.rawImageFroMPlatformFile(file);
+    if (rawImage != null &&
+        rawImage.image != null &&
+        PngUtils.isPng(rawImage.image!)) {
+      return [rawImage];
+    }
+    return [];
+  }
+
+  List<FlitesImage> _processAndScaleImages(List<RawImageAndName> images) {
     final scalingFactor = ImageUtils.getScalingFactorForMultipleImages(
-      images: imagesAndNames.map((e) => e.image!).toList(),
+      images: images.map((e) => e.image!).toList(),
       sizeLongestSideOnCanvas: defaultSizeOnCanvas,
     );
 
-    // Sort images by name
-    imagesAndNames.sort((a, b) => (a.name ?? '').compareTo(b.name ?? ''));
+    // Sort images by frame number
+    images.sort((a, b) {
+      final numA = int.tryParse(
+              RegExp(r'frame_(\d+)').firstMatch(a.name ?? '')?.group(1) ??
+                  '0') ??
+          0;
+      final numB = int.tryParse(
+              RegExp(r'frame_(\d+)').firstMatch(b.name ?? '')?.group(1) ??
+                  '0') ??
+          0;
+      return numA.compareTo(numB);
+    });
 
-    // Create and return FlitesImages
-    return imagesAndNames
-        .map((img) => FlitesImage.scaled(img.image!,
-            scalingFactor: scalingFactor, originalName: img.name))
+    return images
+        .map((img) => FlitesImage.scaled(
+              img.image!,
+              scalingFactor: scalingFactor,
+              originalName: img.name,
+            ))
         .toList();
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR closes #19. It extends the functionality of `ImagePickerService` with the option to drop a `gif`. This gif then is split into it's frames (skipping the first composite layer) and converts them into `pngs`.
![Selection_019](https://github.com/user-attachments/assets/ed55b095-a77f-4d1a-ac17-33c756a94d5f)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
