### PR TITLE
Fix/beau project file list overflow

### DIFF
--- a/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
+++ b/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
@@ -112,177 +112,190 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                     ],
                   ),
                 ),
-                ReorderableListView(
-                  buildDefaultDragHandles: false,
-                  scrollDirection: Axis.vertical,
-                  shrinkWrap: true,
-                  scrollController: _scrollController,
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  proxyDecorator: (child, index, animation) {
-                    return AnimatedBuilder(
-                      animation: animation,
-                      builder: (context, child) {
-                        return Transform.scale(
-                          scale: 1.05,
-                          child: Material(
-                            color: Colors.transparent,
-                            child: child,
+                Expanded(
+                  child: ReorderableListView(
+                    buildDefaultDragHandles: false,
+                    scrollDirection: Axis.vertical,
+                    shrinkWrap: true,
+                    scrollController: _scrollController,
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    proxyDecorator: (child, index, animation) {
+                      return AnimatedBuilder(
+                        animation: animation,
+                        builder: (context, child) {
+                          return Transform.scale(
+                            scale: 1.05,
+                            child: Material(
+                              color: Colors.transparent,
+                              child: child,
+                            ),
+                          );
+                        },
+                        child: child,
+                      );
+                    },
+                    children:
+                        projectSourceFiles.value.asMap().entries.map((entry) {
+                      return ReorderableDragStartListener(
+                        key: Key('file-${entry.key}'),
+                        index: entry.key,
+                        child: FileItem(
+                          file: entry.value,
+                          key: Key('file-item-${entry.key}'),
+                        ),
+                      );
+                    }).toList(),
+                    onReorder: (oldIndex, newIndex) {
+                      if (oldIndex < newIndex) {
+                        newIndex -= 1;
+                      }
+                      final List<FlitesImage> currentImages =
+                          List.from(projectSourceFiles.value);
+                      final item = currentImages.removeAt(oldIndex);
+                      currentImages.insert(newIndex, item);
+                      projectSourceFiles.value = currentImages;
+                    },
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    HoverableWidget(
+                      builder: (isHovered) {
+                        return GestureDetector(
+                          onTap: () async {
+                            final newImages =
+                                await imagePickerService.pickAndProcessImages();
+                            if (newImages.isNotEmpty) {
+                              projectSourceFiles.value = [
+                                ...projectSourceFiles.value,
+                                ...newImages,
+                              ];
+                            }
+                          },
+                          child: Container(
+                            width: double.infinity,
+                            margin: const EdgeInsets.symmetric(
+                              vertical: 2,
+                              horizontal: 8,
+                            ),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 24,
+                              vertical: 8,
+                            ),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(8),
+                              color: isHovered
+                                  ? context.colors.surface
+                                  : Colors.transparent,
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  CupertinoIcons.add,
+                                  size: 16,
+                                  color: context.colors.surfaceDim,
+                                ),
+                                const SizedBox(width: 16),
+                                const Text('Add Image'),
+                              ],
+                            ),
                           ),
                         );
                       },
-                      child: child,
-                    );
-                  },
-                  children:
-                      projectSourceFiles.value.asMap().entries.map((entry) {
-                    return ReorderableDragStartListener(
-                      key: Key('file-${entry.key}'),
-                      index: entry.key,
-                      child: FileItem(
-                        file: entry.value,
-                        key: Key('file-item-${entry.key}'),
-                      ),
-                    );
-                  }).toList(),
-                  onReorder: (oldIndex, newIndex) {
-                    if (oldIndex < newIndex) {
-                      newIndex -= 1;
-                    }
-                    final List<FlitesImage> currentImages =
-                        List.from(projectSourceFiles.value);
-                    final item = currentImages.removeAt(oldIndex);
-                    currentImages.insert(newIndex, item);
-                    projectSourceFiles.value = currentImages;
-                  },
-                ),
-                HoverableWidget(
-                  builder: (isHovered) {
-                    return GestureDetector(
-                      onTap: () async {
-                        final newImages =
-                            await imagePickerService.pickAndProcessImages();
-                        if (newImages.isNotEmpty) {
-                          projectSourceFiles.value = [
-                            ...projectSourceFiles.value,
-                            ...newImages,
-                          ];
-                        }
-                      },
-                      child: Container(
-                        width: double.infinity,
-                        margin: const EdgeInsets.symmetric(
-                          vertical: 2,
-                          horizontal: 8,
-                        ),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 8,
-                        ),
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(8),
-                          color: isHovered
-                              ? context.colors.surface
-                              : Colors.transparent,
-                        ),
-                        child: Row(
-                          children: [
-                            Icon(
-                              CupertinoIcons.add,
-                              size: 16,
-                              color: context.colors.surfaceDim,
-                            ),
-                            const SizedBox(width: 16),
-                            const Text('Add Image'),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                const Spacer(),
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: OverlayButton(
-                    tooltip: 'Canvas and Image Controls',
-                    buttonChild: Container(
-                      padding: const EdgeInsets.all(6),
-                      decoration: BoxDecoration(
-                        color: context.colors.surfaceContainerLow,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Icon(
-                        CupertinoIcons.layers,
-                        color: context.colors.surfaceDim,
-                      ),
                     ),
-                    overlayContent: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: SizedBox(
-                        width: 280,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const ControlHeader(text: 'Canvas Controls'),
-                            CheckboxButton(
-                              text: 'Use Previous Frame as Reference',
-                              value: usePreviousImageAsReference,
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: OverlayButton(
+                        tooltip: 'Canvas and Image Controls',
+                        buttonChild: Container(
+                          padding: const EdgeInsets.all(6),
+                          decoration: BoxDecoration(
+                            color: context.colors.surfaceContainerLow,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Icon(
+                            CupertinoIcons.layers,
+                            color: context.colors.surfaceDim,
+                          ),
+                        ),
+                        overlayContent: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: SizedBox(
+                            width: 280,
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const ControlHeader(text: 'Canvas Controls'),
+                                CheckboxButton(
+                                  text: 'Use Previous Frame as Reference',
+                                  value: usePreviousImageAsReference,
+                                ),
+                                CheckboxButton(
+                                  text: 'Show bounding border',
+                                  value:
+                                      canvasController.showBoundingBorderSignal,
+                                ),
+                                const SizedBox(height: 32),
+                                const ControlHeader(text: 'Image Controls'),
+                                IconTextButton(
+                                  onPressed: () {
+                                    final images = [
+                                      ...projectSourceFiles.value
+                                    ];
+
+                                    images.sort((a, b) {
+                                      if (a.displayName != null &&
+                                          b.displayName != null) {
+                                        return a.displayName!
+                                            .compareTo(b.displayName!);
+                                      }
+
+                                      return 0;
+                                    });
+
+                                    projectSourceFiles.value = images;
+                                  },
+                                  text: 'Sort by name',
+                                ),
+                                IconTextButton(
+                                  onPressed: () {
+                                    final images = [
+                                      ...projectSourceFiles.value
+                                    ];
+
+                                    for (int i = 1; i <= images.length; i++) {
+                                      final img = images[i - 1];
+                                      img.displayName = 'frame_$i.png';
+                                    }
+
+                                    projectSourceFiles.value = images;
+                                  },
+                                  text: 'Rename Files according to order',
+                                ),
+                                IconTextButton(
+                                  onPressed: () {
+                                    final images = [
+                                      ...projectSourceFiles.value
+                                    ];
+
+                                    for (int i = 1; i <= images.length; i++) {
+                                      final img = images[i - 1];
+                                      img.displayName = img.originalName;
+                                    }
+
+                                    projectSourceFiles.value = images;
+                                  },
+                                  text: 'Reset Names',
+                                ),
+                              ],
                             ),
-                            CheckboxButton(
-                              text: 'Show bounding border',
-                              value: canvasController.showBoundingBorderSignal,
-                            ),
-                            const SizedBox(height: 32),
-                            const ControlHeader(text: 'Image Controls'),
-                            IconTextButton(
-                              onPressed: () {
-                                final images = [...projectSourceFiles.value];
-
-                                images.sort((a, b) {
-                                  if (a.displayName != null &&
-                                      b.displayName != null) {
-                                    return a.displayName!
-                                        .compareTo(b.displayName!);
-                                  }
-
-                                  return 0;
-                                });
-
-                                projectSourceFiles.value = images;
-                              },
-                              text: 'Sort by name',
-                            ),
-                            IconTextButton(
-                              onPressed: () {
-                                final images = [...projectSourceFiles.value];
-
-                                for (int i = 1; i <= images.length; i++) {
-                                  final img = images[i - 1];
-                                  img.displayName = 'frame_$i.png';
-                                }
-
-                                projectSourceFiles.value = images;
-                              },
-                              text: 'Rename Files according to order',
-                            ),
-                            IconTextButton(
-                              onPressed: () {
-                                final images = [...projectSourceFiles.value];
-
-                                for (int i = 1; i <= images.length; i++) {
-                                  final img = images[i - 1];
-                                  img.displayName = img.originalName;
-                                }
-
-                                projectSourceFiles.value = images;
-                              },
-                              text: 'Reset Names',
-                            ),
-                          ],
+                          ),
                         ),
                       ),
                     ),
-                  ),
+                  ],
                 ),
               ],
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR is branched off of #30, so please merge #30 first :) 

It closes #28 by removing the `const Spacer()` and allowing the project file list to take in the whole available height.


<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/d9cc4e1a-a960-4d6b-9dc7-034b366ac1da" alt="Image 1" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/be95324a-7929-490d-af80-1c708e46106c" alt="Image 2" width="300"></td>
  </tr>
</table>



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
