### PR TITLE
refactor: Use App Sizes instead of hardcoded dimensions

### DIFF
--- a/apps/flites/lib/constants/app_sizes.dart
+++ b/apps/flites/lib/constants/app_sizes.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+// Define common app sizes
+const double menuBarHeight = 24;
+
+/// Constant sizes for paddings, gaps, rounded corners etc.
+class Sizes {
+  static const p2 = 2.0;
+  static const p4 = 4.0;
+  static const p8 = 8.0;
+  static const p12 = 12.0;
+  static const p16 = 16.0;
+  static const p20 = 20.0;
+  static const p24 = 24.0;
+  static const p32 = 32.0;
+  static const p36 = 36.0;
+  static const p40 = 40.0;
+  static const p42 = 42.0;
+  static const p48 = 48.0;
+  static const p64 = 64.0;
+}
+
+/// Constant gap widths
+const gapW4 = SizedBox(width: Sizes.p4);
+const gapW8 = SizedBox(width: Sizes.p8);
+const gapW12 = SizedBox(width: Sizes.p12);
+const gapW16 = SizedBox(width: Sizes.p16);
+const gapW20 = SizedBox(width: Sizes.p20);
+const gapW24 = SizedBox(width: Sizes.p24);
+const gapW32 = SizedBox(width: Sizes.p32);
+const gapW40 = SizedBox(width: Sizes.p40);
+const gapW48 = SizedBox(width: Sizes.p48);
+const gapW64 = SizedBox(width: Sizes.p64);
+
+/// Constant gap heights
+const gapH4 = SizedBox(height: Sizes.p4);
+const gapH8 = SizedBox(height: Sizes.p8);
+const gapH12 = SizedBox(height: Sizes.p12);
+const gapH16 = SizedBox(height: Sizes.p16);
+const gapH20 = SizedBox(height: Sizes.p20);
+const gapH24 = SizedBox(height: Sizes.p24);
+const gapH32 = SizedBox(height: Sizes.p32);
+const gapH40 = SizedBox(height: Sizes.p40);
+const gapH48 = SizedBox(height: Sizes.p48);
+const gapH64 = SizedBox(height: Sizes.p64);

--- a/apps/flites/lib/screens/overview.dart
+++ b/apps/flites/lib/screens/overview.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/widgets/blocking_widget/blocking_container.dart';
 import 'package:flites/widgets/canvas_controls/canvas_controls.dart';
 import 'package:flites/widgets/canvas_controls/zoom_controls.dart';
@@ -37,8 +38,8 @@ class _OverviewState extends State<Overview> {
                   children: [
                     ImageEditor(),
                     Positioned(
-                      right: 32,
-                      bottom: 32,
+                      right: Sizes.p32,
+                      bottom: Sizes.p32,
                       child: ZoomControls(),
                     ),
                   ],
@@ -49,7 +50,7 @@ class _OverviewState extends State<Overview> {
           ),
           BlockingContainer(),
           Positioned(
-            bottom: 64,
+            bottom: Sizes.p64,
             child: PlayerControls(),
           ),
         ],

--- a/apps/flites/lib/widgets/buttons/icon_text_button.dart
+++ b/apps/flites/lib/widgets/buttons/icon_text_button.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flutter/material.dart';
 
 class IconTextButton extends StatelessWidget {
@@ -17,7 +18,7 @@ class IconTextButton extends StatelessWidget {
     return InkWell(
       onTap: onPressed,
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 6),
+        padding: const EdgeInsets.symmetric(vertical: Sizes.p8),
         child: icon == null
             ? Text(text)
             : Row(

--- a/apps/flites/lib/widgets/buttons/stadium_button.dart
+++ b/apps/flites/lib/widgets/buttons/stadium_button.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/material.dart';
 
@@ -7,7 +8,7 @@ class StadiumButton extends StatelessWidget {
     required this.text,
     this.onPressed,
     this.color,
-    this.height = 48,
+    this.height = Sizes.p48,
     this.width = 140,
   });
 
@@ -27,7 +28,7 @@ class StadiumButton extends StatelessWidget {
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: color ?? context.colors.onSurface,
-          borderRadius: BorderRadius.circular(32),
+          borderRadius: BorderRadius.circular(Sizes.p32),
         ),
         child: Text(
           text,

--- a/apps/flites/lib/widgets/canvas_controls/zoom_controls.dart
+++ b/apps/flites/lib/widgets/canvas_controls/zoom_controls.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/canvas_controller.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +12,7 @@ class ZoomControls extends StatelessWidget {
       // width: 64,
       decoration: BoxDecoration(
         color: context.colors.surfaceContainerLowest,
-        borderRadius: BorderRadius.circular(32),
+        borderRadius: BorderRadius.circular(Sizes.p32),
       ),
       child: Column(
         children: [
@@ -22,7 +23,7 @@ class ZoomControls extends StatelessWidget {
             },
             icon: Icon(
               Icons.zoom_out,
-              size: 28,
+              size: Sizes.p24,
               color: context.colors.surfaceContainer,
             ),
           ),
@@ -33,7 +34,7 @@ class ZoomControls extends StatelessWidget {
             },
             icon: Icon(
               Icons.zoom_in,
-              size: 28,
+              size: Sizes.p24,
               color: context.colors.surfaceContainer,
             ),
           ),

--- a/apps/flites/lib/widgets/controls/checkbox_button.dart
+++ b/apps/flites/lib/widgets/controls/checkbox_button.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/material.dart';
 import 'package:signals/signals_flutter.dart';
@@ -33,7 +34,7 @@ class CheckboxButton extends StatelessWidget {
                 isChecked ? Icons.check_circle : Icons.circle_outlined,
                 color: context.colors.surfaceDim,
               ),
-              const SizedBox(width: 8),
+              gapW8,
               Expanded(
                 child: Text(
                   text,

--- a/apps/flites/lib/widgets/error_box/error_box.dart
+++ b/apps/flites/lib/widgets/error_box/error_box.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flutter/material.dart';
 
 class ErrorBox extends StatelessWidget {
@@ -11,11 +12,11 @@ class ErrorBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(8),
-      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(Sizes.p8),
+      margin: const EdgeInsets.symmetric(vertical: Sizes.p8),
       decoration: BoxDecoration(
         color: Colors.red,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(Sizes.p8),
         border: Border.all(color: Colors.red),
       ),
       child: Text(

--- a/apps/flites/lib/widgets/export/export_dialog_content.dart
+++ b/apps/flites/lib/widgets/export/export_dialog_content.dart
@@ -6,6 +6,7 @@ import 'package:flites/widgets/export/numeric_input_with_buttons.dart';
 import 'package:flites/widgets/export/padding_input.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flites/constants/app_sizes.dart';
 
 class ExportDialogContent extends StatefulWidget {
   const ExportDialogContent({super.key});
@@ -41,12 +42,12 @@ class ExportDialogContentState extends State<ExportDialogContent> {
               context.l10n.exportSprite,
               style: Theme.of(context).textTheme.titleLarge,
             ),
-            const SizedBox(height: 24),
+            gapH24,
             Text(
               context.l10n.fileName,
               style: Theme.of(context).textTheme.titleSmall,
             ),
-            const SizedBox(height: 8),
+            gapH8,
             TextField(
               decoration: InputDecoration(
                 hintText: context.l10n.enterSpriteName,
@@ -57,7 +58,7 @@ class ExportDialogContentState extends State<ExportDialogContent> {
               ),
               controller: fileNameController,
             ),
-            const SizedBox(height: 24),
+            gapH24,
             Row(
               children: [
                 Expanded(
@@ -71,7 +72,7 @@ class ExportDialogContentState extends State<ExportDialogContent> {
                     },
                   ),
                 ),
-                const SizedBox(width: 8),
+                gapW8,
                 Expanded(
                   child: NumericInputWithButtons(
                     label: '${context.l10n.height} (px)',
@@ -85,7 +86,7 @@ class ExportDialogContentState extends State<ExportDialogContent> {
                 ),
               ],
             ),
-            const SizedBox(height: 24),
+            gapH24,
             PaddingInput(
               topPadding: currentPaddingTop,
               bottomPadding: currentPaddingBottom,
@@ -112,28 +113,28 @@ class ExportDialogContentState extends State<ExportDialogContent> {
                 });
               },
             ),
-            const SizedBox(height: 24),
+            gapH24,
             if (!kIsWeb) ...[
               Text(
                 'Location',
                 style: Theme.of(context).textTheme.titleSmall,
               ),
-              const SizedBox(height: 8),
+              gapH8,
               FilePathPicker(
                 onPathSelected: (selectedPath) {
                   exportPath = selectedPath;
                 },
               ),
-              const SizedBox(height: 24),
+              gapH24,
             ],
             if (kIsWeb) ...[
               Text(
                 context.l10n.webDownloadLocation,
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
-              const SizedBox(height: 16),
+              gapH16,
             ],
-            const SizedBox(height: 16),
+            gapH16,
             Align(
               alignment: Alignment.centerRight,
               child: StadiumButton(

--- a/apps/flites/lib/widgets/export/numeric_input_with_buttons.dart
+++ b/apps/flites/lib/widgets/export/numeric_input_with_buttons.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/material.dart';
 
@@ -26,7 +27,7 @@ class NumericInputWithButtons extends StatelessWidget {
             label!,
             style: Theme.of(context).textTheme.titleSmall,
           ),
-          const SizedBox(height: 4),
+          gapH4,
         ],
         Container(
           height: 40,

--- a/apps/flites/lib/widgets/export/numeric_input_with_buttons.dart
+++ b/apps/flites/lib/widgets/export/numeric_input_with_buttons.dart
@@ -30,10 +30,10 @@ class NumericInputWithButtons extends StatelessWidget {
           gapH4,
         ],
         Container(
-          height: 40,
+          height: Sizes.p40,
           decoration: BoxDecoration(
             border: Border.all(color: context.colors.onSurface),
-            borderRadius: BorderRadius.circular(4),
+            borderRadius: BorderRadius.circular(Sizes.p4),
             color: context.colors.surface,
           ),
           child: Row(
@@ -44,7 +44,7 @@ class NumericInputWithButtons extends StatelessWidget {
                   keyboardType: TextInputType.number,
                   decoration: InputDecoration(
                     hintText: currentValue.toString(),
-                    contentPadding: const EdgeInsets.only(left: 8),
+                    contentPadding: const EdgeInsets.only(left: Sizes.p8),
                     border: InputBorder.none,
                     fillColor: context.colors.surface,
                     isDense: true,
@@ -64,7 +64,7 @@ class NumericInputWithButtons extends StatelessWidget {
                     },
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(),
-                    iconSize: 16,
+                    iconSize: Sizes.p16,
                     color: context.colors.onSurface,
                   ),
                   IconButton(
@@ -74,7 +74,7 @@ class NumericInputWithButtons extends StatelessWidget {
                     },
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(),
-                    iconSize: 16,
+                    iconSize: Sizes.p16,
                     color: context.colors.onSurface,
                   ),
                 ],

--- a/apps/flites/lib/widgets/export/padding_input.dart
+++ b/apps/flites/lib/widgets/export/padding_input.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/material.dart';
 import 'numeric_input_with_buttons.dart';
@@ -45,7 +46,7 @@ class PaddingInput extends StatelessWidget {
             onChanged: onTopChanged,
           ),
         ),
-        const SizedBox(height: 16),
+        gapH16,
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -66,7 +67,7 @@ class PaddingInput extends StatelessWidget {
             ),
           ],
         ),
-        const SizedBox(height: 16),
+        gapH16,
         SizedBox(
           width: 100,
           child: NumericInputWithButtons(

--- a/apps/flites/lib/widgets/image_editor/image_editor.dart
+++ b/apps/flites/lib/widgets/image_editor/image_editor.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/canvas_controller.dart';
 import 'package:flites/states/key_events.dart';
@@ -172,7 +173,7 @@ class _ImageEditorState extends State<ImageEditor> {
                         child: Container(
                           decoration: BoxDecoration(
                             border: Border.all(
-                              width: 4,
+                              width: Sizes.p4,
                               color: context.colors.surfaceContainerLowest,
                             ),
                           ),

--- a/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
+++ b/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
@@ -1,8 +1,8 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:signals/signals_flutter.dart';
-import 'package:flites/constants/app_sizes.dart';
 
 final showLoadingOverlay = signal(false);
 
@@ -27,15 +27,18 @@ class LoadingOverlay extends StatelessWidget {
       color: Colors.black54,
       child: Center(
         child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Sizes.p24,
+            vertical: Sizes.p16,
+          ),
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface,
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(Sizes.p16),
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withValues(alpha: 0.1),
-                blurRadius: 12,
-                offset: const Offset(0, 4),
+                blurRadius: Sizes.p12,
+                offset: const Offset(0, Sizes.p4),
               ),
             ],
           ),
@@ -46,7 +49,7 @@ class LoadingOverlay extends StatelessWidget {
               if (kIsWeb)
                 const Icon(
                   Icons.hourglass_empty,
-                  size: 32,
+                  size: Sizes.p32,
                 )
               else
                 const CircularProgressIndicator(),

--- a/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
+++ b/apps/flites/lib/widgets/loading_overlay/loading_overlay.dart
@@ -2,6 +2,7 @@ import 'package:flites/main.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:signals/signals_flutter.dart';
+import 'package:flites/constants/app_sizes.dart';
 
 final showLoadingOverlay = signal(false);
 
@@ -41,7 +42,7 @@ class LoadingOverlay extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const SizedBox(height: 8),
+              gapH8,
               if (kIsWeb)
                 const Icon(
                   Icons.hourglass_empty,
@@ -49,12 +50,12 @@ class LoadingOverlay extends StatelessWidget {
                 )
               else
                 const CircularProgressIndicator(),
-              const SizedBox(height: 24),
+              gapH24,
               Text(
                 context.l10n.processingImage,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
-              const SizedBox(height: 8),
+              gapH8,
               Text(
                 context.l10n.processingMightTakeAMoment,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/apps/flites/lib/widgets/menu_bar/app_menu_bar.dart
+++ b/apps/flites/lib/widgets/menu_bar/app_menu_bar.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flutter/material.dart';
 import 'package:menu_bar/menu_bar.dart';
 import 'package:flites/main.dart';
@@ -12,25 +13,25 @@ class AppMenuBar extends StatelessWidget {
 
   final Widget child;
 
-  static const double _indicatorWidth = 16.0;
-  static const double _menuHeight = 24.0;
+  static const double _indicatorWidth = Sizes.p16;
   static const checkIcon = Icon(Icons.check, size: _indicatorWidth);
   static const emptySpace = SizedBox(width: _indicatorWidth);
 
   MenuStyle _createMenuStyle(BuildContext context) => MenuStyle(
         backgroundColor:
             WidgetStatePropertyAll(context.colors.surfaceContainerLow),
-        fixedSize: const WidgetStatePropertyAll(Size.fromHeight(_menuHeight)),
+        fixedSize: const WidgetStatePropertyAll(Size.fromHeight(menuBarHeight)),
         padding: const WidgetStatePropertyAll(EdgeInsets.zero),
       );
 
   ButtonStyle _createButtonStyle(BuildContext context) => ButtonStyle(
         backgroundColor:
             WidgetStatePropertyAll(context.colors.surfaceContainerLow),
-        fixedSize: const WidgetStatePropertyAll(Size.fromHeight(_menuHeight)),
-        padding:
-            const WidgetStatePropertyAll(EdgeInsets.symmetric(horizontal: 8)),
-        minimumSize: const WidgetStatePropertyAll(Size.fromHeight(_menuHeight)),
+        fixedSize: const WidgetStatePropertyAll(Size.fromHeight(menuBarHeight)),
+        padding: const WidgetStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: Sizes.p8)),
+        minimumSize:
+            const WidgetStatePropertyAll(Size.fromHeight(menuBarHeight)),
       );
 
   MenuButton _buildThemeMenuItem(String text, ThemeMode mode) {

--- a/apps/flites/lib/widgets/player/player.dart
+++ b/apps/flites/lib/widgets/player/player.dart
@@ -73,7 +73,7 @@ class _PlayerControlsState extends State<PlayerControls> {
         color: context.colors.surfaceContainerLowest,
         borderRadius: BorderRadius.circular(32),
       ),
-      height: 64,
+      height: Sizes.p64,
       width: 344,
       child: Watch(
         (context) {
@@ -87,7 +87,7 @@ class _PlayerControlsState extends State<PlayerControls> {
                 child: Text(
                   'Player Speed',
                   style: TextStyle(
-                    fontSize: 16,
+                    fontSize: Sizes.p16,
                     color: context.colors.outline,
                   ),
                 ),
@@ -101,7 +101,7 @@ class _PlayerControlsState extends State<PlayerControls> {
                   ],
                   textAlign: TextAlign.end,
                   style: TextStyle(
-                    fontSize: 16,
+                    fontSize: Sizes.p16,
                     fontWeight: FontWeight.w700,
                     color: context.colors.onSurfaceVariant,
                   ),
@@ -109,7 +109,7 @@ class _PlayerControlsState extends State<PlayerControls> {
                     suffix: Text(
                       ' ms',
                       style: TextStyle(
-                        fontSize: 16,
+                        fontSize: Sizes.p16,
                         fontWeight: FontWeight.w400,
                         color: context.colors.surfaceContainerHighest,
                       ),

--- a/apps/flites/lib/widgets/player/player.dart
+++ b/apps/flites/lib/widgets/player/player.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/open_project.dart';
 import 'package:flites/utils/get_flite_image.dart';
@@ -81,7 +82,7 @@ class _PlayerControlsState extends State<PlayerControls> {
 
           return Row(
             children: [
-              const SizedBox(width: 32),
+              gapW32,
               Flexible(
                 child: Text(
                   'Player Speed',
@@ -91,7 +92,7 @@ class _PlayerControlsState extends State<PlayerControls> {
                   ),
                 ),
               ),
-              const SizedBox(width: 16),
+              gapW16,
               SizedBox(
                 width: 100,
                 child: TextField(
@@ -141,7 +142,7 @@ class _PlayerControlsState extends State<PlayerControls> {
                           .withValues(alpha: 0.38),
                 ),
               ),
-              const SizedBox(width: 32),
+              gapW32,
             ],
           );
         },

--- a/apps/flites/lib/widgets/project_file_list/file_item.dart
+++ b/apps/flites/lib/widgets/project_file_list/file_item.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/open_project.dart';
 import 'package:flites/states/selected_images_controller.dart';
@@ -32,10 +33,16 @@ class _FileItemState extends State<FileItem> {
         onEnter: (event) => isHoveredState.value = true,
         onExit: (event) => isHoveredState.value = false,
         child: Container(
-          margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+          margin: const EdgeInsets.symmetric(
+            vertical: Sizes.p2,
+            horizontal: Sizes.p8,
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Sizes.p24,
+            vertical: Sizes.p8,
+          ),
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(Sizes.p8),
             color: isCurrentlySelected
                 ? Theme.of(context).primaryColor.withValues(alpha: 0.3)
                 : isHovered
@@ -52,13 +59,16 @@ class _FileItemState extends State<FileItem> {
                 Image.memory(
                   widget.file.image,
                   fit: BoxFit.contain,
-                  width: 24,
-                  height: 24,
+                  width: Sizes.p24,
+                  height: Sizes.p24,
                 ),
                 if (widget.file.displayName != null)
                   Expanded(
                     child: Padding(
-                      padding: const EdgeInsets.only(left: 24, right: 16),
+                      padding: const EdgeInsets.only(
+                        left: Sizes.p24,
+                        right: Sizes.p16,
+                      ),
                       child: Text(
                         widget.file.displayName!,
                         overflow: TextOverflow.ellipsis,
@@ -67,7 +77,7 @@ class _FileItemState extends State<FileItem> {
                   ),
                 if (isHovered)
                   Padding(
-                    padding: const EdgeInsets.only(left: 16),
+                    padding: const EdgeInsets.only(left: Sizes.p16),
                     child: Tooltip(
                       message: context.l10n.delete,
                       child: InkWell(
@@ -76,13 +86,13 @@ class _FileItemState extends State<FileItem> {
                             ...projectSourceFiles.value
                           ]..removeWhere((e) => e.id == widget.file.id);
                         },
-                        child: const Icon(Icons.delete, size: 16),
+                        child: const Icon(Icons.delete, size: Sizes.p16),
                       ),
                     ),
                   ),
                 if (isCurrentReferenceImage || isHovered)
                   Padding(
-                    padding: const EdgeInsets.only(left: 16),
+                    padding: const EdgeInsets.only(left: Sizes.p16),
                     child: Tooltip(
                       message: context.l10n.toggleVisibility,
                       child: InkWell(
@@ -101,7 +111,7 @@ class _FileItemState extends State<FileItem> {
                         },
                         child: const Icon(
                           CupertinoIcons.eye_solid,
-                          size: 16,
+                          size: Sizes.p16,
                           // color: Colors.grey,
                         ),
                       ),

--- a/apps/flites/lib/widgets/project_file_list/project_file_item.dart
+++ b/apps/flites/lib/widgets/project_file_list/project_file_item.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/selected_images_controller.dart';
 import 'package:flites/types/flites_image.dart';
@@ -24,9 +25,9 @@ class ProjectFileItem extends StatelessWidget {
         final isCurrentlySelected = selectedImage.value == file.id;
 
         return Container(
-          margin: const EdgeInsets.only(right: 8),
+          margin: const EdgeInsets.only(right: Sizes.p8),
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(Sizes.p8),
             border: isCurrentlySelected
                 ? Border.all(
                     color: Theme.of(context).colorScheme.primary,
@@ -35,13 +36,13 @@ class ProjectFileItem extends StatelessWidget {
                 : isHovered
                     ? Border.all(
                         color: Theme.of(context).colorScheme.primary,
-                        width: 2,
+                        width: Sizes.p2,
                       )
                     : null,
           ),
           width: 150,
           height: 150,
-          padding: const EdgeInsets.all(8),
+          padding: const EdgeInsets.all(Sizes.p8),
           child: MouseRegion(
             onEnter: (event) => isHoveredState.value = true,
             onExit: (event) => isHoveredState.value = false,
@@ -64,10 +65,10 @@ class ProjectFileItem extends StatelessWidget {
                       top: 0,
                       right: 0,
                       child: Container(
-                        padding: const EdgeInsets.all(4),
+                        padding: const EdgeInsets.all(Sizes.p4),
                         decoration: BoxDecoration(
                           color: Theme.of(context).colorScheme.primary,
-                          borderRadius: BorderRadius.circular(4),
+                          borderRadius: BorderRadius.circular(Sizes.p4),
                         ),
                         child: Icon(
                           Icons.edit,
@@ -81,10 +82,10 @@ class ProjectFileItem extends StatelessWidget {
                     top: 0,
                     right: 0,
                     child: Container(
-                      padding: const EdgeInsets.all(4),
+                      padding: const EdgeInsets.all(Sizes.p4),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.primary,
-                        borderRadius: BorderRadius.circular(4),
+                        borderRadius: BorderRadius.circular(Sizes.p4),
                       ),
                       child: Icon(
                         Icons.remove_red_eye_outlined,

--- a/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
+++ b/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/canvas_controller.dart';
 import 'package:flites/states/open_project.dart';
@@ -55,7 +56,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 16),
+                gapH16,
                 Padding(
                   padding: const EdgeInsets.only(left: 16.0, right: 32.0),
                   child: Row(
@@ -67,13 +68,13 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                         icon: CupertinoIcons.square_split_2x2,
                         tooltip: context.l10n.canvasMode,
                       ),
-                      const SizedBox(width: 16),
+                      gapW16,
                       ToolButton(
                         tool: Tool.move,
                         icon: CupertinoIcons.move,
                         tooltip: context.l10n.moveTool,
                       ),
-                      const SizedBox(width: 16),
+                      gapW16,
                       ToolButton(
                         tool: Tool.rotate,
                         icon: CupertinoIcons.rotate_right,
@@ -82,7 +83,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 8),
+                gapH8,
                 Padding(
                   padding: const EdgeInsets.only(left: 16.0, right: 32.0),
                   child: Row(
@@ -196,7 +197,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                                   size: 16,
                                   color: context.colors.surfaceDim,
                                 ),
-                                const SizedBox(width: 16),
+                                gapW16,
                                 Text(context.l10n.addImage),
                               ],
                             ),
@@ -239,7 +240,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                                   value:
                                       canvasController.showBoundingBorderSignal,
                                 ),
-                                const SizedBox(height: 32),
+                                gapH32,
                                 ControlHeader(
                                     text: context.l10n.canvasControls),
                                 IconTextButton(

--- a/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
+++ b/apps/flites/lib/widgets/project_file_list/project_file_list_vertical.dart
@@ -43,13 +43,13 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.all(Sizes.p16),
                   child: Row(
                     children: [
                       Text(
                         context.l10n.title,
                         style: const TextStyle(
-                          fontSize: 36,
+                          fontSize: Sizes.p36,
                           fontWeight: FontWeight.w800,
                         ),
                       ),
@@ -58,7 +58,10 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                 ),
                 gapH16,
                 Padding(
-                  padding: const EdgeInsets.only(left: 16.0, right: 32.0),
+                  padding: const EdgeInsets.only(
+                    left: Sizes.p16,
+                    right: Sizes.p32,
+                  ),
                   child: Row(
                     children: [
                       ControlHeader(text: context.l10n.tools),
@@ -85,7 +88,10 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                 ),
                 gapH8,
                 Padding(
-                  padding: const EdgeInsets.only(left: 16.0, right: 32.0),
+                  padding: const EdgeInsets.only(
+                    left: Sizes.p16,
+                    right: Sizes.p32,
+                  ),
                   child: Row(
                     children: [
                       ControlHeader(text: context.l10n.frames),
@@ -106,7 +112,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                           },
                           child: const Icon(
                             CupertinoIcons.eye_solid,
-                            size: 16,
+                            size: Sizes.p16,
                           ),
                         ),
                       ),
@@ -177,15 +183,15 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                           child: Container(
                             width: double.infinity,
                             margin: const EdgeInsets.symmetric(
-                              vertical: 2,
-                              horizontal: 8,
+                              vertical: Sizes.p2,
+                              horizontal: Sizes.p8,
                             ),
                             padding: const EdgeInsets.symmetric(
-                              horizontal: 24,
-                              vertical: 8,
+                              horizontal: Sizes.p24,
+                              vertical: Sizes.p8,
                             ),
                             decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(8),
+                              borderRadius: BorderRadius.circular(Sizes.p8),
                               color: isHovered
                                   ? context.colors.surface
                                   : Colors.transparent,
@@ -194,7 +200,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                               children: [
                                 Icon(
                                   CupertinoIcons.add,
-                                  size: 16,
+                                  size: Sizes.p16,
                                   color: context.colors.surfaceDim,
                                 ),
                                 gapW16,
@@ -206,14 +212,14 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                       },
                     ),
                     Padding(
-                      padding: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(Sizes.p16),
                       child: OverlayButton(
                         tooltip: context.l10n.canvasAndImageControls,
                         buttonChild: Container(
-                          padding: const EdgeInsets.all(6),
+                          padding: const EdgeInsets.all(Sizes.p8),
                           decoration: BoxDecoration(
                             color: context.colors.surfaceContainerLow,
-                            borderRadius: BorderRadius.circular(8),
+                            borderRadius: BorderRadius.circular(Sizes.p8),
                           ),
                           child: Icon(
                             CupertinoIcons.layers,
@@ -221,7 +227,7 @@ class _ProjectFileListVerticalState extends State<ProjectFileListVertical> {
                           ),
                         ),
                         overlayContent: Padding(
-                          padding: const EdgeInsets.all(16.0),
+                          padding: const EdgeInsets.all(Sizes.p16),
                           child: SizedBox(
                             width: 280,
                             child: Column(

--- a/apps/flites/lib/widgets/project_file_list/tool_button.dart
+++ b/apps/flites/lib/widgets/project_file_list/tool_button.dart
@@ -1,3 +1,4 @@
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/tool_controller.dart';
 import 'package:flutter/material.dart';
@@ -46,11 +47,11 @@ class ToolButton extends StatelessWidget {
                     : isHovered
                         ? context.colors.surfaceTint
                         : Colors.transparent,
-                borderRadius: BorderRadius.circular(4),
+                borderRadius: BorderRadius.circular(Sizes.p4),
               ),
               child: Icon(
                 icon,
-                size: 16,
+                size: Sizes.p16,
                 color: isSelected
                     ? context.colors.surfaceContainerLowest
                     : context.colors.onSurface,

--- a/apps/flites/lib/widgets/rotation/rotation_wrapper.dart
+++ b/apps/flites/lib/widgets/rotation/rotation_wrapper.dart
@@ -75,7 +75,7 @@ class _RotationWrapperState extends State<RotationWrapper> {
       alignment: Alignment.center,
       children: [
         Padding(
-          padding: const EdgeInsets.only(bottom: 50),
+          padding: const EdgeInsets.only(bottom: Sizes.p48),
           child: Transform.rotate(
             origin: const Offset(0, 0),
             angle: rotation,
@@ -97,7 +97,7 @@ class _RotationWrapperState extends State<RotationWrapper> {
                       shape: BoxShape.circle,
                       border: Border.all(
                         color: context.colors.outline,
-                        width: 2,
+                        width: Sizes.p2,
                       ),
                     ),
                     width: circleRadius * 2 - (dotSize * 2 / 3),
@@ -139,9 +139,12 @@ class _RotationWrapperState extends State<RotationWrapper> {
             child: Container(
               decoration: BoxDecoration(
                 color: context.colors.surfaceContainerLowest,
-                borderRadius: BorderRadius.circular(32),
+                borderRadius: BorderRadius.circular(Sizes.p32),
               ),
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              padding: const EdgeInsets.symmetric(
+                horizontal: Sizes.p8,
+                vertical: Sizes.p4,
+              ),
               child: Row(
                 children: [
                   IconButton(

--- a/apps/flites/lib/widgets/rotation/rotation_wrapper.dart
+++ b/apps/flites/lib/widgets/rotation/rotation_wrapper.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flites/states/open_project.dart';
 import 'package:flites/utils/get_flite_image.dart';
@@ -153,7 +154,7 @@ class _RotationWrapperState extends State<RotationWrapper> {
                       dragStartPoint = Offset(0, circleRadius);
                     },
                   ),
-                  const SizedBox(width: 8),
+                  gapW8,
                   IconButton(
                     icon: const Icon(Icons.check),
                     onPressed: () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR closes #40. It adds `app_sizes.dart` where `sizes` and `gaps` are defined. 

These are then used in individual files to replace hardcoded values eg.: 

`width: 24` => `width: Sizes.p24` 
`const SizedBox(width: 24)` => `gapW24`

I'd recommend reviewing the commits individually.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
