### PR TITLE
feat(ci): add reusable workflow foundation and Linux release automation

### DIFF
--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -84,28 +84,31 @@ runs:
         SUFFIX_TEMPLATE_KEY=""
         ARTIFACT_NAME_TEMPLATE_KEY=""
 
-        if [ "${EVENT_NAME}" == "workflow_call" ]; then
-          BUILD_TYPE="release"
-          TAG_INPUT="${{ inputs.tag_input }}"
-          if [ -z "${TAG_INPUT}" ]; then echo "Error: Tag input required for release."; exit 1; fi
-          PACKAGE_VERSION=${TAG_INPUT#v} # Use tag version
-          SUFFIX_TEMPLATE_KEY="release_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="release_artifact_name"
+        if [ -n "${TAG_INPUT}" ]; then
+            BUILD_TYPE="release"
+            if [[ ! "${TAG_INPUT}" =~ ^v ]]; then echo "Error: Tag input '${TAG_INPUT}' missing 'v' prefix."; exit 1; fi
+            PACKAGE_VERSION=${TAG_INPUT#v} # Use tag version
+            SUFFIX_TEMPLATE_KEY="release_suffix_template"
+            ARTIFACT_NAME_TEMPLATE_KEY="release_artifact_name"
 
         elif [ "${EVENT_NAME}" == "pull_request" ]; then
-          BUILD_TYPE="pr"
-          PR_NUM="${{ inputs.pr_number }}"
-          if [ -z "${PR_NUM}" ]; then echo "Error: PR number required for PR build."; exit 1; fi
-          PACKAGE_VERSION="0.0.0-pr${PR_NUM}"
-          SUFFIX_TEMPLATE_KEY="pr_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name_template"
+            BUILD_TYPE="pr"
+            if [ -z "${PR_NUM}" ]; then echo "Error: PR number required for PR build."; exit 1; fi
+            PACKAGE_VERSION="0.0.0-pr${PR_NUM}" # Placeholder version
+            SUFFIX_TEMPLATE_KEY="pr_suffix_template"
+            ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name_template"
+
+        elif [ "${EVENT_NAME}" == "workflow_dispatch" ]; then
+            BUILD_TYPE="manual"
+            if [ -z "${RUN_ID}" ]; then echo "Error: Run ID required for manual build."; exit 1; fi
+            PACKAGE_VERSION="0.0.0-manual${RUN_ID}" # Placeholder version
+            SUFFIX_TEMPLATE_KEY="manual_suffix_template"
+            ARTIFACT_NAME_TEMPLATE_KEY="manual_artifact_name_template"
 
         else
-          BUILD_TYPE="manual"
-          RUN_ID="${{ inputs.run_id }}"
-          PACKAGE_VERSION="0.0.0-dev${RUN_ID}"
-          SUFFIX_TEMPLATE_KEY="manual_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="manual_artifact_name_template"
+            # Fallback/Error for unexpected combinations
+            echo "Error: Could not determine build type from event '${EVENT_NAME}' and tag input '${TAG_INPUT}'."
+            exit 1
         fi
 
         # --- Get templates from config file ---

--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -1,0 +1,160 @@
+name: 'Determine Build Variables'
+description: 'Calculates build variables from .github/build_config.yaml based on context.'
+
+# Define the inputs the action expects
+inputs:
+  platform:
+    description: 'Target platform (must match key in build_config.yaml: linux, windows, macos, web)'
+    required: true
+    type: string
+  event_name:
+    description: 'The event that triggered the workflow (e.g., ${{ github.event_name }})'
+    required: true
+    type: string
+  tag_input:
+    description: 'The git tag (e.g., ${{ inputs.tag }} from workflow_call)'
+    required: false # Only provided for workflow_call on tag push
+    type: string
+  pr_number:
+    description: 'The pull request number (e.g., ${{ github.event.number }})'
+    required: false # Only relevant for pull_request event
+    type: string
+  run_id:
+    description: 'The unique ID for the workflow run (e.g., ${{ github.run_id }})'
+    required: false # Mostly relevant for workflow_dispatch
+    type: string
+
+# Define the outputs the action will provide
+outputs:
+  build_type:
+    description: 'Type of build (release, pr, manual)'
+    value: ${{ steps.set_vars.outputs.build_type }}
+  package_version:
+    description: 'Version string (e.g., 1.0.0 or 0.0.0-pr123)'
+    value: ${{ steps.set_vars.outputs.package_version }}
+  artifact_suffix:
+    description: 'Calculated filename suffix including version/platform specifics'
+    value: ${{ steps.set_vars.outputs.artifact_suffix }}
+  artifact_upload_name:
+    description: 'Calculated name for actions/upload-artifact'
+    value: ${{ steps.set_vars.outputs.artifact_upload_name }}
+
+runs:
+  using: "composite" # Specify that this is a composite action
+  steps:
+    # Step 1: Checkout code to access the config file in the repo
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Step 2: Install yq (YAML processor)
+    # Adjust if not using Linux runner or if yq is pre-installed
+    - name: Install yq
+      shell: bash
+      run: |
+        if ! command -v yq &> /dev/null; then
+          echo "Installing yq..."
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+        fi
+        yq --version
+
+    # Step 3: Calculate variables based on context and config file
+    - name: Calculate Variables
+      id: set_vars # Give the step an ID to reference its outputs
+      shell: bash
+      run: |
+        set -e # Exit script immediately if any command fails
+
+        # --- Use the config file name the user chose ---
+        CONFIG_FILE=".github/build_config.yaml"
+        PLATFORM="${{ inputs.platform }}"
+        EVENT_NAME="${{ inputs.event_name }}"
+
+        echo "Reading config from: ${CONFIG_FILE}"
+        echo "Running for event: ${EVENT_NAME}, Platform: ${PLATFORM}"
+
+        if [ ! -f "${CONFIG_FILE}" ]; then
+          echo "Error: Config file not found at ${CONFIG_FILE}"
+          exit 1
+        fi
+
+        # --- Determine Build Type & Base Version ---
+        BUILD_TYPE=""
+        PACKAGE_VERSION=""
+        PR_NUM=""
+        RUN_ID=""
+        SUFFIX_TEMPLATE_KEY=""
+        ARTIFACT_NAME_TEMPLATE_KEY=""
+
+        if [ "${EVENT_NAME}" == "workflow_call" ]; then
+          BUILD_TYPE="release"
+          TAG_INPUT="${{ inputs.tag_input }}"
+          if [ -z "${TAG_INPUT}" ]; then echo "Error: Tag input required for release."; exit 1; fi
+          PACKAGE_VERSION=${TAG_INPUT#v} # Use tag version
+          SUFFIX_TEMPLATE_KEY="release_suffix_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="release_artifact_name" # Usually static for release
+
+        elif [ "${EVENT_NAME}" == "pull_request" ]; then
+          BUILD_TYPE="pr"
+          PR_NUM="${{ inputs.pr_number }}"
+          if [ -z "${PR_NUM}" ]; then echo "Error: PR number required for PR build."; exit 1; fi
+          PACKAGE_VERSION="0.0.0-pr${PR_NUM}" # Placeholder version
+          SUFFIX_TEMPLATE_KEY="pr_suffix_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name_template"
+
+        elif [ "${EVENT_NAME}" == "workflow_dispatch" ]; then
+          BUILD_TYPE="manual"
+          RUN_ID="${{ inputs.run_id }}"
+          if [ -z "${RUN_ID}" ]; then echo "Error: Run ID required for manual build."; exit 1; fi
+          PACKAGE_VERSION="0.0.0-manual${RUN_ID}" # Placeholder version
+          SUFFIX_TEMPLATE_KEY="manual_suffix_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="manual_artifact_name_template"
+
+        else
+          echo "Error: Unsupported trigger event '${EVENT_NAME}'."
+          exit 1
+        fi
+
+        # --- Read Templates from Config File using yq ---
+        # Construct the yq query paths dynamically
+        SUFFIX_QUERY=".platforms[\"${PLATFORM}\"].${SUFFIX_TEMPLATE_KEY}"
+        ARTIFACT_NAME_QUERY=".platforms[\"${PLATFORM}\"].${ARTIFACT_NAME_TEMPLATE_KEY}"
+
+        echo "Querying suffix template with: ${SUFFIX_QUERY}"
+        SUFFIX_TEMPLATE=$(yq eval "${SUFFIX_QUERY}" "${CONFIG_FILE}")
+
+        echo "Querying artifact name template with: ${ARTIFACT_NAME_QUERY}"
+        ARTIFACT_NAME_TEMPLATE=$(yq eval "${ARTIFACT_NAME_QUERY}" "${CONFIG_FILE}")
+
+        # Check if keys were found
+        if [ "${SUFFIX_TEMPLATE}" == "null" ] || [ -z "${SUFFIX_TEMPLATE}" ]; then
+           echo "Error: Could not find ${SUFFIX_TEMPLATE_KEY} for platform ${PLATFORM} in ${CONFIG_FILE}"
+           exit 1
+        fi
+         if [ "${ARTIFACT_NAME_TEMPLATE}" == "null" ] || [ -z "${ARTIFACT_NAME_TEMPLATE}" ]; then
+           echo "Error: Could not find ${ARTIFACT_NAME_TEMPLATE_KEY} for platform ${PLATFORM} in ${CONFIG_FILE}"
+           exit 1
+        fi
+
+        # --- Perform Placeholder Substitution ---
+        # Using sed for slightly more robust replacement
+        TEMP_SUFFIX=$(echo "${SUFFIX_TEMPLATE}" | sed -e "s/%VERSION%/${PACKAGE_VERSION}/g" -e "s/%PR_NUM%/${PR_NUM}/g" -e "s/%RUN_ID%/${RUN_ID}/g")
+        ARTIFACT_SUFFIX="${TEMP_SUFFIX}"
+
+        TEMP_ARTIFACT_NAME=$(echo "${ARTIFACT_NAME_TEMPLATE}" | sed -e "s/%VERSION%/${PACKAGE_VERSION}/g" -e "s/%PR_NUM%/${PR_NUM}/g" -e "s/%RUN_ID%/${RUN_ID}/g")
+        ARTIFACT_UPLOAD_NAME="${TEMP_ARTIFACT_NAME}"
+
+
+        # --- Set Action Outputs ---
+        echo "Setting outputs..."
+        echo "build_type=${BUILD_TYPE}" >> $GITHUB_OUTPUT
+        echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+        echo "artifact_suffix=${ARTIFACT_SUFFIX}" >> $GITHUB_OUTPUT
+        echo "artifact_upload_name=${ARTIFACT_UPLOAD_NAME}" >> $GITHUB_OUTPUT
+
+        # --- Debug Output (Optional but recommended) ---
+        echo "--- Determined Outputs ---"
+        echo "Build Type: ${BUILD_TYPE}"
+        echo "Package Version: ${PACKAGE_VERSION}"
+        echo "Artifact Suffix: ${ARTIFACT_SUFFIX}"
+        echo "Artifact Upload Name: ${ARTIFACT_UPLOAD_NAME}"
+        echo "--------------------------"

--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -64,10 +64,20 @@ runs:
         echo "DEBUG: Action received tag_input: ${{ inputs.tag_input }}"
         set -e
 
+        # --- Determine Build Type & Base Version ---
+        BUILD_TYPE=""
+        PACKAGE_VERSION=""
+        PR_NUM=""
+        RUN_ID=""
+        SUFFIX_TEMPLATE_KEY=""
+
         # --- Use the config file name the user chose ---
         CONFIG_FILE=".github/build_config.yaml"
         PLATFORM="${{ inputs.platform }}"
         EVENT_NAME="${{ inputs.event_name }}"
+        TAG_INPUT="${{ inputs.tag_input }}"
+        PR_NUM="${{ inputs.pr_number }}"
+        RUN_ID="${{ inputs.run_id }}"
 
         echo "Reading config from: ${CONFIG_FILE}"
         echo "Running for event: ${EVENT_NAME}, Platform: ${PLATFORM}"
@@ -77,13 +87,7 @@ runs:
           exit 1
         fi
 
-        # --- Determine Build Type & Base Version ---
-        BUILD_TYPE=""
-        PACKAGE_VERSION=""
-        PR_NUM=""
-        RUN_ID=""
-        SUFFIX_TEMPLATE_KEY=""
-        ARTIFACT_NAME_TEMPLATE_KEY=""
+
 
         if [ -n "${TAG_INPUT}" ]; then
             BUILD_TYPE="release"

--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -8,20 +8,20 @@ inputs:
     required: true
     type: string
   event_name:
-    description: 'The event that triggered the workflow (e.g., ${{ github.event_name }})'
+    description: 'The event that triggered the workflow (e.g., workflow_call, pull_request, workflow_dispatch)'
     required: true
     type: string
   tag_input:
-    description: 'The git tag (e.g., ${{ inputs.tag }} from workflow_call)'
-    required: false # Only provided for workflow_call on tag push
+    description: 'The git tag for release builds (only provided for workflow_call on tag push)'
+    required: false
     type: string
   pr_number:
-    description: 'The pull request number (e.g., ${{ github.event.number }})'
-    required: false # Only relevant for pull_request event
+    description: 'The pull request number (only relevant for pull_request event)'
+    required: false
     type: string
   run_id:
-    description: 'The unique ID for the workflow run (e.g., ${{ github.run_id }})'
-    required: false # Mostly relevant for workflow_dispatch
+    description: 'The unique ID for the workflow run (mostly relevant for workflow_dispatch)'
+    required: false
     type: string
 
 # Define the outputs the action will provide
@@ -40,14 +40,13 @@ outputs:
     value: ${{ steps.set_vars.outputs.artifact_upload_name }}
 
 runs:
-  using: "composite" # Specify that this is a composite action
+  using: "composite"
   steps:
     # Step 1: Checkout code to access the config file in the repo
     - name: Checkout code
       uses: actions/checkout@v4
 
     # Step 2: Install yq (YAML processor)
-    # Adjust if not using Linux runner or if yq is pre-installed
     - name: Install yq
       shell: bash
       run: |
@@ -59,10 +58,10 @@ runs:
 
     # Step 3: Calculate variables based on context and config file
     - name: Calculate Variables
-      id: set_vars # Give the step an ID to reference its outputs
+      id: set_vars
       shell: bash
       run: |
-        set -e # Exit script immediately if any command fails
+        set -e
 
         # --- Use the config file name the user chose ---
         CONFIG_FILE=".github/build_config.yaml"
@@ -91,70 +90,39 @@ runs:
           if [ -z "${TAG_INPUT}" ]; then echo "Error: Tag input required for release."; exit 1; fi
           PACKAGE_VERSION=${TAG_INPUT#v} # Use tag version
           SUFFIX_TEMPLATE_KEY="release_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="release_artifact_name" # Usually static for release
+          ARTIFACT_NAME_TEMPLATE_KEY="release_artifact_name"
 
         elif [ "${EVENT_NAME}" == "pull_request" ]; then
           BUILD_TYPE="pr"
           PR_NUM="${{ inputs.pr_number }}"
           if [ -z "${PR_NUM}" ]; then echo "Error: PR number required for PR build."; exit 1; fi
-          PACKAGE_VERSION="0.0.0-pr${PR_NUM}" # Placeholder version
+          PACKAGE_VERSION="0.0.0-pr${PR_NUM}"
           SUFFIX_TEMPLATE_KEY="pr_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name_template"
-
-        elif [ "${EVENT_NAME}" == "workflow_dispatch" ]; then
-          BUILD_TYPE="manual"
-          RUN_ID="${{ inputs.run_id }}"
-          if [ -z "${RUN_ID}" ]; then echo "Error: Run ID required for manual build."; exit 1; fi
-          PACKAGE_VERSION="0.0.0-manual${RUN_ID}" # Placeholder version
-          SUFFIX_TEMPLATE_KEY="manual_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="manual_artifact_name_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name"
 
         else
-          echo "Error: Unsupported trigger event '${EVENT_NAME}'."
-          exit 1
+          BUILD_TYPE="manual"
+          RUN_ID="${{ inputs.run_id }}"
+          PACKAGE_VERSION="0.0.0-dev${RUN_ID}"
+          SUFFIX_TEMPLATE_KEY="dev_suffix_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="dev_artifact_name"
         fi
 
-        # --- Read Templates from Config File using yq ---
-        # Construct the yq query paths dynamically
-        SUFFIX_QUERY=".platforms[\"${PLATFORM}\"].${SUFFIX_TEMPLATE_KEY}"
-        ARTIFACT_NAME_QUERY=".platforms[\"${PLATFORM}\"].${ARTIFACT_NAME_TEMPLATE_KEY}"
+        # --- Get templates from config file ---
+        ARTIFACT_SUFFIX=$(yq eval ".${PLATFORM}.${SUFFIX_TEMPLATE_KEY}" "${CONFIG_FILE}")
+        ARTIFACT_UPLOAD_NAME=$(yq eval ".${PLATFORM}.${ARTIFACT_NAME_TEMPLATE_KEY}" "${CONFIG_FILE}")
 
-        echo "Querying suffix template with: ${SUFFIX_QUERY}"
-        SUFFIX_TEMPLATE=$(yq eval "${SUFFIX_QUERY}" "${CONFIG_FILE}")
+        # --- Replace placeholders in templates ---
+        ARTIFACT_SUFFIX=$(echo "${ARTIFACT_SUFFIX}" | sed "s/\${VERSION}/${PACKAGE_VERSION}/g")
+        ARTIFACT_SUFFIX=$(echo "${ARTIFACT_SUFFIX}" | sed "s/\${PR_NUM}/${PR_NUM}/g")
+        ARTIFACT_SUFFIX=$(echo "${ARTIFACT_SUFFIX}" | sed "s/\${RUN_ID}/${RUN_ID}/g")
 
-        echo "Querying artifact name template with: ${ARTIFACT_NAME_QUERY}"
-        ARTIFACT_NAME_TEMPLATE=$(yq eval "${ARTIFACT_NAME_QUERY}" "${CONFIG_FILE}")
+        ARTIFACT_UPLOAD_NAME=$(echo "${ARTIFACT_UPLOAD_NAME}" | sed "s/\${VERSION}/${PACKAGE_VERSION}/g")
+        ARTIFACT_UPLOAD_NAME=$(echo "${ARTIFACT_UPLOAD_NAME}" | sed "s/\${PR_NUM}/${PR_NUM}/g")
+        ARTIFACT_UPLOAD_NAME=$(echo "${ARTIFACT_UPLOAD_NAME}" | sed "s/\${RUN_ID}/${RUN_ID}/g")
 
-        # Check if keys were found
-        if [ "${SUFFIX_TEMPLATE}" == "null" ] || [ -z "${SUFFIX_TEMPLATE}" ]; then
-           echo "Error: Could not find ${SUFFIX_TEMPLATE_KEY} for platform ${PLATFORM} in ${CONFIG_FILE}"
-           exit 1
-        fi
-         if [ "${ARTIFACT_NAME_TEMPLATE}" == "null" ] || [ -z "${ARTIFACT_NAME_TEMPLATE}" ]; then
-           echo "Error: Could not find ${ARTIFACT_NAME_TEMPLATE_KEY} for platform ${PLATFORM} in ${CONFIG_FILE}"
-           exit 1
-        fi
-
-        # --- Perform Placeholder Substitution ---
-        # Using sed for slightly more robust replacement
-        TEMP_SUFFIX=$(echo "${SUFFIX_TEMPLATE}" | sed -e "s/%VERSION%/${PACKAGE_VERSION}/g" -e "s/%PR_NUM%/${PR_NUM}/g" -e "s/%RUN_ID%/${RUN_ID}/g")
-        ARTIFACT_SUFFIX="${TEMP_SUFFIX}"
-
-        TEMP_ARTIFACT_NAME=$(echo "${ARTIFACT_NAME_TEMPLATE}" | sed -e "s/%VERSION%/${PACKAGE_VERSION}/g" -e "s/%PR_NUM%/${PR_NUM}/g" -e "s/%RUN_ID%/${RUN_ID}/g")
-        ARTIFACT_UPLOAD_NAME="${TEMP_ARTIFACT_NAME}"
-
-
-        # --- Set Action Outputs ---
-        echo "Setting outputs..."
+        # --- Set outputs ---
         echo "build_type=${BUILD_TYPE}" >> $GITHUB_OUTPUT
         echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
         echo "artifact_suffix=${ARTIFACT_SUFFIX}" >> $GITHUB_OUTPUT
         echo "artifact_upload_name=${ARTIFACT_UPLOAD_NAME}" >> $GITHUB_OUTPUT
-
-        # --- Debug Output (Optional but recommended) ---
-        echo "--- Determined Outputs ---"
-        echo "Build Type: ${BUILD_TYPE}"
-        echo "Package Version: ${PACKAGE_VERSION}"
-        echo "Artifact Suffix: ${ARTIFACT_SUFFIX}"
-        echo "Artifact Upload Name: ${ARTIFACT_UPLOAD_NAME}"
-        echo "--------------------------"

--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -98,19 +98,19 @@ runs:
           if [ -z "${PR_NUM}" ]; then echo "Error: PR number required for PR build."; exit 1; fi
           PACKAGE_VERSION="0.0.0-pr${PR_NUM}"
           SUFFIX_TEMPLATE_KEY="pr_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name"
+          ARTIFACT_NAME_TEMPLATE_KEY="pr_artifact_name_template"
 
         else
           BUILD_TYPE="manual"
           RUN_ID="${{ inputs.run_id }}"
           PACKAGE_VERSION="0.0.0-dev${RUN_ID}"
-          SUFFIX_TEMPLATE_KEY="dev_suffix_template"
-          ARTIFACT_NAME_TEMPLATE_KEY="dev_artifact_name"
+          SUFFIX_TEMPLATE_KEY="manual_suffix_template"
+          ARTIFACT_NAME_TEMPLATE_KEY="manual_artifact_name_template"
         fi
 
         # --- Get templates from config file ---
-        ARTIFACT_SUFFIX=$(yq eval ".${PLATFORM}.${SUFFIX_TEMPLATE_KEY}" "${CONFIG_FILE}")
-        ARTIFACT_UPLOAD_NAME=$(yq eval ".${PLATFORM}.${ARTIFACT_NAME_TEMPLATE_KEY}" "${CONFIG_FILE}")
+        ARTIFACT_SUFFIX=$(yq eval ".platforms.${PLATFORM}.${SUFFIX_TEMPLATE_KEY}" "${CONFIG_FILE}")
+        ARTIFACT_UPLOAD_NAME=$(yq eval ".platforms.${PLATFORM}.${ARTIFACT_NAME_TEMPLATE_KEY}" "${CONFIG_FILE}")
 
         # --- Replace placeholders in templates ---
         ARTIFACT_SUFFIX=$(echo "${ARTIFACT_SUFFIX}" | sed "s/\${VERSION}/${PACKAGE_VERSION}/g")

--- a/.github/actions/determine_build_vars/action.yaml
+++ b/.github/actions/determine_build_vars/action.yaml
@@ -61,6 +61,7 @@ runs:
       id: set_vars
       shell: bash
       run: |
+        echo "DEBUG: Action received tag_input: ${{ inputs.tag_input }}"
         set -e
 
         # --- Use the config file name the user chose ---

--- a/.github/build_config.yaml
+++ b/.github/build_config.yaml
@@ -1,29 +1,29 @@
 platforms:
   linux:
-    release_suffix_template: '%VERSION%-x86_64.AppImage'
-    pr_suffix_template: 'pr%PR_NUM%-x86_64.AppImage'
-    manual_suffix_template: 'manual%RUN_ID%-x86_64.AppImage'
+    release_suffix_template: '${VERSION}-x86_64.AppImage'
+    pr_suffix_template: 'pr${PR_NUM}-x86_64.AppImage'
+    manual_suffix_template: 'manual${RUN_ID}-x86_64.AppImage'
     release_artifact_name: 'linux-artifact' # Consistent name for release job
-    pr_artifact_name_template: 'linux-pr-build-%PR_NUM%' # Unique name for PR check
-    manual_artifact_name_template: 'linux-manual-build-%RUN_ID%' # Unique name for manual run
+    pr_artifact_name_template: 'linux-pr-build-${PR_NUM}' # Unique name for PR check
+    manual_artifact_name_template: 'linux-manual-build-${RUN_ID}' # Unique name for manual run
   windows:
-    release_suffix_template: '%VERSION%-windows-x64.zip' # Adjust extension if needed (e.g., .exe, .msix)
-    pr_suffix_template: 'pr%PR_NUM%-windows-x64.zip'
-    manual_suffix_template: 'manual%RUN_ID%-windows-x64.zip'
+    release_suffix_template: '${VERSION}-windows-x64.zip' # Adjust extension if needed (e.g., .exe, .msix)
+    pr_suffix_template: 'pr${PR_NUM}-windows-x64.zip'
+    manual_suffix_template: 'manual${RUN_ID}-windows-x64.zip'
     release_artifact_name: 'windows-artifact'
-    pr_artifact_name_template: 'windows-pr-build-%PR_NUM%'
-    manual_artifact_name_template: 'windows-manual-build-%RUN_ID%'
+    pr_artifact_name_template: 'windows-pr-build-${PR_NUM}'
+    manual_artifact_name_template: 'windows-manual-build-${RUN_ID}'
   macos:
-    release_suffix_template: '%VERSION%-macos-x64.zip' # Usually a zip of the .app
-    pr_suffix_template: 'pr%PR_NUM%-macos-x64.zip'
-    manual_suffix_template: 'manual%RUN_ID%-macos-x64.zip'
+    release_suffix_template: '${VERSION}-macos-x64.zip' # Usually a zip of the .app
+    pr_suffix_template: 'pr${PR_NUM}-macos-x64.zip'
+    manual_suffix_template: 'manual${RUN_ID}-macos-x64.zip'
     release_artifact_name: 'macos-artifact'
-    pr_artifact_name_template: 'macos-pr-build-%PR_NUM%'
-    manual_artifact_name_template: 'macos-manual-build-%RUN_ID%'
+    pr_artifact_name_template: 'macos-pr-build-${PR_NUM}'
+    manual_artifact_name_template: 'macos-manual-build-${RUN_ID}'
   web:
-    release_suffix_template: '%VERSION%-web' # Example: No zip extension needed
-    pr_suffix_template: 'pr%PR_NUM%-web'
-    manual_suffix_template: 'manual%RUN_ID%-web'
+    release_suffix_template: '${VERSION}-web' # Example: No zip extension needed
+    pr_suffix_template: 'pr${PR_NUM}-web'
+    manual_suffix_template: 'manual${RUN_ID}-web'
     release_artifact_name: 'web-artifact' 
-    pr_artifact_name_template: 'web-pr-build-%PR_NUM%'
-    manual_artifact_name_template: 'web-manual-build-%RUN_ID%'
+    pr_artifact_name_template: 'web-pr-build-${PR_NUM}'
+    manual_artifact_name_template: 'web-manual-build-${RUN_ID}'

--- a/.github/build_config.yaml
+++ b/.github/build_config.yaml
@@ -3,9 +3,9 @@ platforms:
     release_suffix_template: 'flites-${VERSION}-x86_64.AppImage'
     pr_suffix_template: 'flites-pr${PR_NUM}-x86_64.AppImage'
     manual_suffix_template: 'flites-manual${RUN_ID}-x86_64.AppImage'
-    release_artifact_name: 'linux-artifact' # Consistent name for release job
-    pr_artifact_name_template: 'linux-pr-build-${PR_NUM}' # Unique name for PR check
-    manual_artifact_name_template: 'linux-manual-build-${RUN_ID}' # Unique name for manual run
+    release_artifact_name: 'flites-linux-artifact' # Consistent name for release job
+    pr_artifact_name_template: 'flites-linux-pr-build-${PR_NUM}' # Unique name for PR check
+    manual_artifact_name_template: 'flites-linux-manual-build-${RUN_ID}' # Unique name for manual run
   windows:
     release_suffix_template: '${VERSION}-windows-x64.zip' # Adjust extension if needed (e.g., .exe, .msix)
     pr_suffix_template: 'pr${PR_NUM}-windows-x64.zip'

--- a/.github/build_config.yaml
+++ b/.github/build_config.yaml
@@ -1,8 +1,8 @@
 platforms:
   linux:
-    release_suffix_template: '${VERSION}-x86_64.AppImage'
-    pr_suffix_template: 'pr${PR_NUM}-x86_64.AppImage'
-    manual_suffix_template: 'manual${RUN_ID}-x86_64.AppImage'
+    release_suffix_template: 'flites-${VERSION}-x86_64.AppImage'
+    pr_suffix_template: 'flites-pr${PR_NUM}-x86_64.AppImage'
+    manual_suffix_template: 'flites-manual${RUN_ID}-x86_64.AppImage'
     release_artifact_name: 'linux-artifact' # Consistent name for release job
     pr_artifact_name_template: 'linux-pr-build-${PR_NUM}' # Unique name for PR check
     manual_artifact_name_template: 'linux-manual-build-${RUN_ID}' # Unique name for manual run

--- a/.github/build_config.yaml
+++ b/.github/build_config.yaml
@@ -1,0 +1,29 @@
+platforms:
+  linux:
+    release_suffix_template: '%VERSION%-x86_64.AppImage'
+    pr_suffix_template: 'pr%PR_NUM%-x86_64.AppImage'
+    manual_suffix_template: 'manual%RUN_ID%-x86_64.AppImage'
+    release_artifact_name: 'linux-artifact' # Consistent name for release job
+    pr_artifact_name_template: 'linux-pr-build-%PR_NUM%' # Unique name for PR check
+    manual_artifact_name_template: 'linux-manual-build-%RUN_ID%' # Unique name for manual run
+  windows:
+    release_suffix_template: '%VERSION%-windows-x64.zip' # Adjust extension if needed (e.g., .exe, .msix)
+    pr_suffix_template: 'pr%PR_NUM%-windows-x64.zip'
+    manual_suffix_template: 'manual%RUN_ID%-windows-x64.zip'
+    release_artifact_name: 'windows-artifact'
+    pr_artifact_name_template: 'windows-pr-build-%PR_NUM%'
+    manual_artifact_name_template: 'windows-manual-build-%RUN_ID%'
+  macos:
+    release_suffix_template: '%VERSION%-macos-x64.zip' # Usually a zip of the .app
+    pr_suffix_template: 'pr%PR_NUM%-macos-x64.zip'
+    manual_suffix_template: 'manual%RUN_ID%-macos-x64.zip'
+    release_artifact_name: 'macos-artifact'
+    pr_artifact_name_template: 'macos-pr-build-%PR_NUM%'
+    manual_artifact_name_template: 'macos-manual-build-%RUN_ID%'
+  web:
+    release_suffix_template: '%VERSION%-web' # Example: No zip extension needed
+    pr_suffix_template: 'pr%PR_NUM%-web'
+    manual_suffix_template: 'manual%RUN_ID%-web'
+    release_artifact_name: 'web-artifact' 
+    pr_artifact_name_template: 'web-pr-build-%PR_NUM%'
+    manual_artifact_name_template: 'web-manual-build-%RUN_ID%'

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -135,18 +135,18 @@ jobs:
 
       - name: 📦 Create AppImage
         run: |
-          ARCH=x86_64 appimagetool AppDir ${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}
+          ARCH=x86_64 appimagetool AppDir ${{ steps.vars.outputs.artifact_suffix }}
 
       - name: ⬆️ Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.vars.outputs.artifact_upload_name }}
-          path: ${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}
+          path: ${{ steps.vars.outputs.artifact_suffix }}
 
       - name: 🧪 Test AppImage
         run: |
           # Use the dynamic filename determined by the composite action
-          APPIMAGE_FILE="${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}"
+          APPIMAGE_FILE="${{ steps.vars.outputs.artifact_suffix }}"
 
           chmod +x "${APPIMAGE_FILE}"
 

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -24,8 +24,6 @@ jobs:
       APP_NAME: Flites
       APP_ID: com.marqably.flites
       APP_NAME_LOWER: flites
-    outputs:
-      artifact_name: ${{ steps.vars.outputs.artifact_upload_name }}
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -139,12 +137,6 @@ jobs:
         run: |
           ARCH=x86_64 appimagetool AppDir ${{ steps.vars.outputs.artifact_suffix }}
 
-      - name: 🔍 Debug Paths
-        run: |
-          echo "Artifact suffix: ${{ steps.vars.outputs.artifact_suffix }}"
-          echo "Artifact upload name: ${{ steps.vars.outputs.artifact_upload_name }}"
-          ls -l "${{ steps.vars.outputs.artifact_suffix }}"
-
       - name: ⬆️ Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -175,22 +167,3 @@ jobs:
             which /${APPIMAGE_FILE}" # Or other basic tests like --appimage-extract
 
           docker rm -f $CONTAINER_ID 
-  
-  test-download:
-    runs-on: ubuntu-latest
-    needs: build-appimage 
-    steps:
-      - name: Download artifact produced by build job
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.vars.outputs.artifact_upload_name }}
-
-      - name: List downloaded files
-        run: |
-          echo "Listing files in current directory:"
-          ls -lA ./
-          echo "------------------"
-          echo "Checking file type (if artifact was a single file):"
-          # Try to identify the type of the expected file if it exists
-          # The artifact name might be different on download if it was zipped by UI?
-          # Let's just list everything first. The ls output is key.

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -24,6 +24,8 @@ jobs:
       APP_NAME: Flites
       APP_ID: com.marqably.flites
       APP_NAME_LOWER: flites
+    outputs:
+      artifact_name: ${{ steps.vars.outputs.artifact_upload_name }}
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
@@ -173,3 +175,22 @@ jobs:
             which /${APPIMAGE_FILE}" # Or other basic tests like --appimage-extract
 
           docker rm -f $CONTAINER_ID 
+  
+  test-download:
+    runs-on: ubuntu-latest
+    needs: build-appimage 
+    steps:
+      - name: Download artifact produced by build job
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.vars.outputs.artifact_upload_name }}
+
+      - name: List downloaded files
+        run: |
+          echo "Listing files in current directory:"
+          ls -lA ./
+          echo "------------------"
+          echo "Checking file type (if artifact was a single file):"
+          # Try to identify the type of the expected file if it exists
+          # The artifact name might be different on download if it was zipped by UI?
+          # Let's just list everything first. The ls output is key.

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -25,6 +25,10 @@ jobs:
       APP_ID: com.marqably.flites
       APP_NAME_LOWER: flites
     steps:
+      - name: DEBUG Print Workflow Input Tag
+        run: |
+          echo "Workflow Input (inputs.tag): ${{ inputs.tag }}"
+
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -137,6 +137,12 @@ jobs:
         run: |
           ARCH=x86_64 appimagetool AppDir ${{ steps.vars.outputs.artifact_suffix }}
 
+      - name: 🔍 Debug Paths
+        run: |
+          echo "Artifact suffix: ${{ steps.vars.outputs.artifact_suffix }}"
+          echo "Artifact upload name: ${{ steps.vars.outputs.artifact_upload_name }}"
+          ls -l "${{ steps.vars.outputs.artifact_suffix }}"
+
       - name: ⬆️ Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -1,46 +1,52 @@
 name: 🐧 AppImage Build
 
-env:
-  PACKAGE_VERSION: 0.0.1
-
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Git tag for release builds.'
+        required: false
+        type: string
+      flutter-version:
+        description: 'Flutter version (optional).'
+        required: false
+        type: string
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-appimage:
     name: 🐧 Build and Deploy AppImage
     runs-on: ubuntu-22.04
+    env:
+      APP_NAME: Flites
+      APP_ID: com.marqably.flites
+      APP_NAME_LOWER: flites
     steps:
       - name: 📚 Git Checkout
         uses: actions/checkout@v4
+        with:
+          # Checkout tag only if called for release, otherwise default
+          ref: ${{ github.event_name == 'workflow_call' && inputs.tag || github.ref }}
+
+      - name: Determine Build Context & Variables
+        id: vars
+        uses: ./.github/actions/determine_build_vars@main
+        with:
+          platform: 'linux'
+          event_name: ${{ github.event_name }}
+          tag_input: ${{ inputs.tag }}
+          pr_number: ${{ github.event.number }}
+          run_id: ${{ github.run_id }}
 
       - name: 📦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.2'
+          flutter-version: ${{ inputs.flutter-version || '3.27.2' }}
           architecture: x64
-
-      - name: 🗄️ Cache Flutter
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/flutter
-          key: flutter-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
-
-      - name: 🗄️ Cache Pub Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          cache: true
 
       - name: 📦 Setup Melos
         uses: bluefireteam/melos-action@v2
@@ -75,21 +81,21 @@ jobs:
 
       - name: 🖥️ Create Desktop Entry
         run: |
-          cat > AppDir/flites.desktop << EOL
+          cat > AppDir/${{ env.APP_NAME_LOWER }}.desktop << EOL
           [Desktop Entry]
-          Name=Flites
-          Exec=flites
-          Icon=flites
+          Name=${{ env.APP_NAME }}
+          Exec=${{ env.APP_NAME_LOWER }}
+          Icon=${{ env.APP_NAME_LOWER }}
           Type=Application
           Categories=Utility;
           Comment=A sprite generator written in flutter
           EOL
-          cp AppDir/flites.desktop AppDir/usr/share/applications/
+          cp AppDir/${{ env.APP_NAME_LOWER }}.desktop AppDir/usr/share/applications/
 
       - name: 🎨 Copy Icons
         run: |
-          cp apps/flites/assets/images/flites_logo.png AppDir/flites.png
-          cp apps/flites/assets/images/flites_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/flites.png
+          cp apps/flites/assets/images/flites_logo.png AppDir/${{ env.APP_NAME_LOWER }}.png
+          cp apps/flites/assets/images/flites_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/${{ env.APP_NAME_LOWER }}.png
 
       - name: 📜 Create AppRun Script
         run: |
@@ -98,17 +104,18 @@ jobs:
           HERE=\$(dirname \$(readlink -f \${0}))
           export PATH="\${HERE}/usr/bin/:\${PATH}"
           export LD_LIBRARY_PATH="\${HERE}/usr/lib/:\${LD_LIBRARY_PATH}"
-          exec "\${HERE}/usr/bin/flites" "\$@"
+          exec "\${HERE}/usr/bin/${{ env.APP_NAME_LOWER }}" "\$@"
           EOL
           chmod +x AppDir/AppRun
 
       - name: 📝 Create Metadata
+        if: steps.vars.outputs.build_type == 'release'
         run: |
-          cat > AppDir/usr/share/metainfo/flites.appdata.xml << EOL
+          cat > AppDir/usr/share/metainfo/${{ env.APP_NAME_LOWER }}.appdata.xml << EOL
           <?xml version="1.0" encoding="UTF-8"?>
           <component type="desktop-application">
-            <id>com.marqably.flites</id>
-            <name>Flites</name>
+            <id>${{ env.APP_ID }}</id>
+            <name>${{ env.APP_NAME }}</name>
             <summary>A sprite generator written in flutter</summary>
             <metadata_license>MIT</metadata_license>
             <project_license>MIT</project_license>
@@ -121,37 +128,42 @@ jobs:
               <category>Utility</category>
             </categories>
             <releases>
-              <release version="${{ env.PACKAGE_VERSION }}" date="2024-03-14"/>
+              <release version="${{ steps.vars.outputs.package_version }}" date="$(date +%Y-%m-%d)"/>
             </releases>
           </component>
           EOL
 
       - name: 📦 Create AppImage
         run: |
-          ARCH=x86_64 appimagetool AppDir flites-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
+          ARCH=x86_64 appimagetool AppDir ${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}
 
       - name: ⬆️ Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: flites-appimage-${{ env.PACKAGE_VERSION }}
-          path: flites-${{ env.PACKAGE_VERSION }}-x86_64.AppImage 
+          name: ${{ steps.vars.outputs.artifact_upload_name }}
+          path: ${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}
 
       - name: 🧪 Test AppImage
         run: |
-          chmod +x flites-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
-          
+          # Use the dynamic filename determined by the composite action
+          APPIMAGE_FILE="${{ env.APP_NAME }}-${{ steps.vars.outputs.artifact_suffix }}"
+
+          chmod +x "${APPIMAGE_FILE}"
+
           CONTAINER_ID=$(docker create -t debian:stable sleep infinity)
           docker start $CONTAINER_ID
-          
+
           docker exec $CONTAINER_ID bash -c "
             set -e && \
             apt-get update && \
             apt-get install -y libgtk-3-0 libfuse2"
-          
-          docker cp flites-${{ env.PACKAGE_VERSION }}-x86_64.AppImage $CONTAINER_ID:/flites.AppImage
-          
+
+          # Copy the file WITHOUT renaming it inside the container
+          docker cp "${APPIMAGE_FILE}" $CONTAINER_ID:/${APPIMAGE_FILE}
+
+          # Use the original dynamic filename inside the container tests
           docker exec $CONTAINER_ID bash -c "
-            chmod +x /flites.AppImage && \
-            which /flites.AppImage"
-          
+            chmod +x /${APPIMAGE_FILE} && \
+            which /${APPIMAGE_FILE}" # Or other basic tests like --appimage-extract
+
           docker rm -f $CONTAINER_ID 

--- a/.github/workflows/appimage_build.yaml
+++ b/.github/workflows/appimage_build.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Determine Build Context & Variables
         id: vars
-        uses: ./.github/actions/determine_build_vars@main
+        uses: ./.github/actions/determine_build_vars
         with:
           platform: 'linux'
           event_name: ${{ github.event_name }}

--- a/.github/workflows/debian_build.yaml
+++ b/.github/workflows/debian_build.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/macos_build.yaml
+++ b/.github/workflows/macos_build.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,9 @@ jobs:
       contents: write 
 
     steps:
+      - name: DEBUG Print Trigger Tag
+        run: |
+         echo "Triggering Tag (github.ref_name): ${{ github.ref_name }}"
       # Step 1: Download all artifacts produced by the 'needs' jobs
       - name: Download all build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,84 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' 
+
+jobs:
+  call_build_linux:
+    name: Call Linux Build 🐧
+    uses: ./.github/workflows/appimage_build.yaml
+    with:
+      tag: ${{ github.ref_name }} 
+      
+    secrets: inherit 
+
+  # call_build_windows:
+  #   name: Call Windows Build ⬜
+  #   uses: ./.github/workflows/build_windows.yaml # Assuming this filename
+  #   with:
+  #     tag: ${{ github.ref_name }}
+  #   secrets: inherit
+
+  # call_build_macos:
+  #   name: Call macOS Build 🍎
+  #   uses: ./.github/workflows/build_macos.yaml # Assuming this filename
+  #   with:
+  #     tag: ${{ github.ref_name }}
+  #   secrets: inherit
+
+  # call_build_web:
+  #   name: Call Web Build 🌐
+  #   uses: ./.github/workflows/build_web.yaml # Assuming this filename
+  #   with:
+  #     tag: ${{ github.ref_name }}
+  #   secrets: inherit
+
+  # --- Publish Release Job ---
+  publish_release:
+    name: Publish GitHub Release 🚀
+    runs-on: ubuntu-latest
+    # This job runs only after all specified build jobs succeed
+    needs:
+      - call_build_linux
+      # - call_build_windows
+      # - call_build_macos
+      # - call_build_web
+
+    permissions:
+      contents: write 
+
+    steps:
+      # Step 1: Download all artifacts produced by the 'needs' jobs
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # No name specified downloads all artifacts from this workflow run
+          path: artifacts # Downloads into ./artifacts/<artifact_name>/
+
+      # Step 2: List downloaded files (for debugging)
+      - name: List downloaded artifacts
+        run: ls -lR artifacts
+
+      # Step 3: Create the GitHub Release and upload assets
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          # tag_name: ${{ github.ref_name }} # Defaults to the tag that triggered workflow
+          name: Release ${{ github.ref_name }} # Names the release (e.g., "Release v1.0.0")
+          body: | # Optional: Add release notes here
+            Released version ${{ github.ref_name }}
+            *(See CHANGELOG.md for details)*
+          draft: false # Set to true to create a draft release instead of publishing
+          prerelease: ${{ contains(github.ref_name, '-') }} # Mark as pre-release if tag contains '-' (e.g., v1.0.0-beta)
+          files: |
+            # Paths to the files *inside* the directories created by download-artifact
+            # The directory name matches the 'release_artifact_name' from your config
+            artifacts/linux-artifact/*.AppImage
+            # artifacts/windows-artifact/*.zip
+            # artifacts/macos-artifact/*.zip
+            # artifacts/web-artifact/* # Might be a directory or zip
+        env:
+          # The GITHUB_TOKEN is automatically available to the workflow
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
           files: |
             # Paths to the files *inside* the directories created by download-artifact
             # The directory name matches the 'release_artifact_name' from your config
-            artifacts/linux-artifact/*.AppImage
+            artifacts/flites-linux-artifact/*.AppImage
             # artifacts/windows-artifact/*.zip
             # artifacts/macos-artifact/*.zip
             # artifacts/web-artifact/* # Might be a directory or zip

--- a/.github/workflows/web_build.yaml
+++ b/.github/workflows/web_build.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/windows_build.yaml
+++ b/.github/workflows/windows_build.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
**Dependency:** Merge #61 first.

**Summary:**
Introduces the core structure for reusable builds and automated releases.

**Changes:**
* Adds composite action `.github/actions/determine_build_vars` with `build_config.yaml` for centralized build variables.
* Refactors Linux build (`appimage_build.yaml`) into a reusable workflow using the composite action.
* Adds initial `release.yaml` workflow triggered by tags.
* Removes the trigger on 'v*' from build workflows themsleves as they will be called through the release action

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
