### PR TITLE
fix(ci): bump Ubuntu in debian-runner to 22.04 

### DIFF
--- a/.github/workflows/debian_build.yaml
+++ b/.github/workflows/debian_build.yaml
@@ -18,13 +18,17 @@ on:
     branches:
       - main
 
+  push: 
+    branches:
+      - fix/beau/debian-runner
+
   # Allows manual triggering
   workflow_dispatch:
 
 jobs:
   build-debian:
     name: 🐧 Build and Deploy Debian
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env: 
       APP_NAME: Flites
       APP_ID: com.marqably.flites

--- a/.github/workflows/debian_build.yaml
+++ b/.github/workflows/debian_build.yaml
@@ -18,10 +18,6 @@ on:
     branches:
       - main
 
-  push: 
-    branches:
-      - fix/beau/debian-runner
-
   # Allows manual triggering
   workflow_dispatch:
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Ubuntu 20.04 (which we previously used) is going to be deprecated. That's why all builds failed. 

closes #79 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build and deployment workflow to use Ubuntu 22.04 for Debian package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->