### PR TITLE
feat: tiled sprite maps

### DIFF
--- a/apps/flites/lib/utils/generate_sprite.dart
+++ b/apps/flites/lib/utils/generate_sprite.dart
@@ -9,16 +9,29 @@ import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
 
 class GenerateSprite {
+  static Future<img.Image?> exportTiledSpriteMap({
+    required Size tileSize,
+  }) async {
+    return exportSpriteMap(tileSize: tileSize);
+  }
+
   static Future<img.Image?> exportSpriteMap({
     FileService? fileService,
+    Size? tileSize,
   }) async {
     final sourceFiles = projectSourceFiles.value;
 
     final spriteRowImages = <img.Image>[];
 
     for (int i = 0; i < sourceFiles.rows.length; i++) {
+      // If [tileSize] is provided, override the export settings of each row
+      // to use a size constrained setting with the tile size as height and
+      // width.
       final spriteRowImage = await createSpriteRowImage(
-        sourceFiles.rows[i].exportSettings,
+        sourceFiles.rows[i].exportSettings.copyWith(
+          heightPx: tileSize?.height.toInt(),
+          widthPx: tileSize?.width.toInt(),
+        ),
         spriteRowIndex: i,
       );
 

--- a/apps/flites/lib/utils/generate_sprite.dart
+++ b/apps/flites/lib/utils/generate_sprite.dart
@@ -31,6 +31,10 @@ class GenerateSprite {
         sourceFiles.rows[i].exportSettings.copyWith(
           heightPx: tileSize?.height.toInt(),
           widthPx: tileSize?.width.toInt(),
+          paddingBottomPx: tileSize != null ? 0 : null,
+          paddingTopPx: tileSize != null ? 0 : null,
+          paddingLeftPx: tileSize != null ? 0 : null,
+          paddingRightPx: tileSize != null ? 0 : null,
         ),
         spriteRowIndex: i,
       );

--- a/apps/flites/lib/utils/generate_sprite.dart
+++ b/apps/flites/lib/utils/generate_sprite.dart
@@ -362,7 +362,7 @@ class GenerateSprite {
     try {
       await fileService.saveFile(
         bytes: spriteData,
-        fileType: FileType.image,
+        fileType: FileType.custom,
         fileExtension: 'png',
       );
     } catch (e) {

--- a/apps/flites/lib/utils/generate_svg_sprite.dart
+++ b/apps/flites/lib/utils/generate_svg_sprite.dart
@@ -14,8 +14,15 @@ import 'package:flutter/material.dart';
 
 /// Handles the generation of SVG sprite sheets from multiple SVG images.
 class GenerateSvgSprite {
+  static Future<void> exportTiledSpriteMap({
+    required Size tileSize,
+  }) async {
+    return exportSpriteMap(tileSize: tileSize);
+  }
+
   static Future<void> exportSpriteMap({
     FileService? fileService,
+    Size? tileSize,
   }) async {
     final sourceFiles = projectSourceFiles.value;
 
@@ -23,7 +30,10 @@ class GenerateSvgSprite {
 
     for (int i = 0; i < sourceFiles.rows.length; i++) {
       final spriteRowImage = await createSpriteRowImage(
-        sourceFiles.rows[i].exportSettings,
+        sourceFiles.rows[i].exportSettings.copyWith(
+          heightPx: tileSize?.height.toInt(),
+          widthPx: tileSize?.width.toInt(),
+        ),
         spriteRowIndex: i,
       );
 

--- a/apps/flites/lib/utils/generate_svg_sprite.dart
+++ b/apps/flites/lib/utils/generate_svg_sprite.dart
@@ -33,6 +33,10 @@ class GenerateSvgSprite {
         sourceFiles.rows[i].exportSettings.copyWith(
           heightPx: tileSize?.height.toInt(),
           widthPx: tileSize?.width.toInt(),
+          paddingBottomPx: tileSize != null ? 0 : null,
+          paddingTopPx: tileSize != null ? 0 : null,
+          paddingLeftPx: tileSize != null ? 0 : null,
+          paddingRightPx: tileSize != null ? 0 : null,
         ),
         spriteRowIndex: i,
       );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Allow for tiled sprite sheet exports, where each frame has the same size.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to export sprite maps with a fixed tile size for both standard and SVG sprite generation.
- **Improvements**
  - Sprite map export now supports specifying custom tile dimensions, allowing for more flexible sprite sheet creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->