### PR TITLE
feat: Clipboard (Copy & Paste)

### DIFF
--- a/apps/flites/lib/screens/overview.dart
+++ b/apps/flites/lib/screens/overview.dart
@@ -6,6 +6,7 @@ import 'package:flites/widgets/image_editor/image_editor.dart';
 import 'package:flites/widgets/image_map_widgets/sprite_map_header_wrapper.dart';
 import 'package:flites/widgets/overlays/update_overlay.dart';
 import 'package:flites/widgets/project_file_list/project_file_list_vertical.dart';
+import 'package:flites/widgets/right_click_menu/right_click_menu_handler.dart';
 import 'package:flites/widgets/tool_controls/tool_controls.dart';
 import 'package:flites/widgets/tool_controls/zoom_controls.dart';
 import 'package:flutter/foundation.dart';
@@ -45,35 +46,37 @@ class _OverviewState extends State<Overview> {
 
   @override
   Widget build(BuildContext context) {
-    return const FileDropArea(
-      child: SpriteMapHeaderWrapper(
-        child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: [
-            Row(
-              children: [
-                ProjectFileListVertical(),
-                Expanded(
-                  child: Stack(
-                    children: [
-                      ImageEditor(),
-                      Positioned(
-                        right: Sizes.p32,
-                        bottom: Sizes.p32,
-                        child: ZoomControls(),
-                      ),
-                    ],
+    return const RightClickMenuHandler(
+      child: FileDropArea(
+        child: SpriteMapHeaderWrapper(
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              Row(
+                children: [
+                  ProjectFileListVertical(),
+                  Expanded(
+                    child: Stack(
+                      children: [
+                        ImageEditor(),
+                        Positioned(
+                          right: Sizes.p32,
+                          bottom: Sizes.p32,
+                          child: ZoomControls(),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                ToolControls()
-              ],
-            ),
-            BlockingContainer(),
-            Positioned(
-              bottom: Sizes.p64,
-              child: PlayerControls(),
-            ),
-          ],
+                  ToolControls()
+                ],
+              ),
+              BlockingContainer(),
+              Positioned(
+                bottom: Sizes.p64,
+                child: PlayerControls(),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/flites/lib/services/clipboard_service.dart
+++ b/apps/flites/lib/services/clipboard_service.dart
@@ -1,0 +1,34 @@
+import 'package:flites/states/source_files_state.dart';
+import 'package:flites/types/flites_image.dart';
+import 'package:flites/utils/flites_image_factory.dart';
+import 'package:signals/signals_flutter.dart';
+
+/// A service that handles copying and pasting images
+/// to and from the clipboard.
+/// - Currently it's only possible to select and therefore copy one image.
+/// - We pass it wrapped by a List to make a change in the future easier.
+class ClipboardService {
+  final _clipboardData = signal<List<FlitesImage?>>([]);
+
+  bool get hasData => _clipboardData.value.isNotEmpty;
+
+  void copyImage(List<FlitesImage> images) async {
+    _clipboardData.value = images;
+  }
+
+  void pasteImage() async {
+    final images = _clipboardData.value;
+
+    if (images.isNotEmpty) {
+      SourceFilesState.pasteExistingImages(
+        flitesImageFactory.duplicateFlitesImages(List.from(images)),
+      );
+    }
+  }
+
+  // void _clearClipboard() {
+  //   _clipboardData.value = null;
+  // }
+}
+
+final clipboardService = ClipboardService();

--- a/apps/flites/lib/states/source_files_state.dart
+++ b/apps/flites/lib/states/source_files_state.dart
@@ -88,7 +88,7 @@ class SourceFilesState {
   }
 
   static Future<void> addImages() async {
-    final newImages = await imagePickerService.pickAndProcessImages();
+    final newImages = await flitesImageFactory.pickAndProcessImages();
 
     final selectedRowIndex = selectedImageRow.value;
     if (newImages.isNotEmpty) {
@@ -107,6 +107,25 @@ class SourceFilesState {
       _projectSourceFiles.value =
           projectSourceFiles.value.copyWith(rows: updatedRows);
     }
+  }
+
+  static Future<void> pasteExistingImages(List<FlitesImage> images) async {
+    final selectedRowIndex = selectedImageRow.value;
+
+    final currentRow = projectSourceFiles.value.rows[selectedRowIndex];
+
+    final updatedRow = currentRow.copyWith(
+      images: [
+        ...currentRow.images,
+        ...images,
+      ],
+    );
+
+    final updatedRows = [...projectSourceFiles.value.rows];
+    updatedRows[selectedRowIndex] = updatedRow;
+
+    _projectSourceFiles.value =
+        projectSourceFiles.value.copyWith(rows: updatedRows);
   }
 
   static void reorderImages(int oldIndex, int newIndex) {

--- a/apps/flites/lib/utils/flites_image_factory.dart
+++ b/apps/flites/lib/utils/flites_image_factory.dart
@@ -160,7 +160,22 @@ class FlitesImageFactory {
       return [];
     }
   }
+
+  /// Duplicates a list of FlitesImage objects for copy and paste operations.
+  List<FlitesImage> duplicateFlitesImages(List<FlitesImage> images) {
+    if (images.isEmpty) return [];
+
+    return images
+        .map(
+          (FlitesImage image) => FlitesImage.scaled(
+            image.image,
+            scalingFactor: image.scalingFactor,
+            originalName: 'copy_${image.originalName}',
+          ),
+        )
+        .toList();
+  }
 }
 
 /// Singleton instance of ImagePickerService
-final imagePickerService = FlitesImageFactory();
+final flitesImageFactory = FlitesImageFactory();

--- a/apps/flites/lib/widgets/project_file_list/file_item.dart
+++ b/apps/flites/lib/widgets/project_file_list/file_item.dart
@@ -33,7 +33,7 @@ class _FileItemState extends State<FileItem> {
       final isCurrentReferenceImage =
           selectedReferenceImages.value.contains(widget.file.id);
 
-      return CopyableItemWrapper<FlitesImage>(
+      return CopyableItemWrapper(
         itemData: widget.file,
         child: MouseRegion(
           onEnter: (event) => isHoveredState.value = true,

--- a/apps/flites/lib/widgets/project_file_list/file_item.dart
+++ b/apps/flites/lib/widgets/project_file_list/file_item.dart
@@ -5,6 +5,7 @@ import 'package:flites/states/selected_image_state.dart';
 import 'package:flites/states/source_files_state.dart';
 import 'package:flites/types/flites_image.dart';
 import 'package:flites/utils/svg_utils.dart';
+import 'package:flites/widgets/right_click_menu/copyable_item_wrapper.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -32,100 +33,103 @@ class _FileItemState extends State<FileItem> {
       final isCurrentReferenceImage =
           selectedReferenceImages.value.contains(widget.file.id);
 
-      return MouseRegion(
-        onEnter: (event) => isHoveredState.value = true,
-        onExit: (event) => isHoveredState.value = false,
-        child: Container(
-          margin: const EdgeInsets.symmetric(
-            vertical: Sizes.p2,
-            horizontal: Sizes.p8,
-          ),
-          padding: const EdgeInsets.symmetric(
-            horizontal: Sizes.p24,
-            vertical: Sizes.p8,
-          ),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(Sizes.p8),
-            color: isCurrentlySelected
-                ? context.colors.surface
-                : isHovered
-                    ? context.colors.surface
-                    : Colors.transparent,
-          ),
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () {
-              SelectedImageState.setSelectedImage(widget.file.id);
-            },
-            child: Row(
-              children: [
-                SvgUtils.isSvg(widget.file.image)
-                    ? SvgPicture.memory(
-                        widget.file.image,
-                        fit: BoxFit.contain,
-                        width: Sizes.p24,
-                        height: Sizes.p24,
-                      )
-                    : Image.memory(
-                        widget.file.image,
-                        fit: BoxFit.contain,
-                        width: Sizes.p24,
-                        height: Sizes.p24,
-                      ),
-                if (widget.file.displayName != null)
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(
-                        left: Sizes.p24,
-                        right: Sizes.p16,
-                      ),
-                      child: Text(
-                        widget.file.displayName!,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ),
-                if (isHovered)
-                  Padding(
-                    padding: const EdgeInsets.only(left: Sizes.p16),
-                    child: Tooltip(
-                      message: context.l10n.delete,
-                      child: InkWell(
-                        onTap: () {
-                          SourceFilesState.deleteImage(widget.file.id);
-                        },
-                        child: const Icon(Icons.delete, size: Sizes.p16),
-                      ),
-                    ),
-                  ),
-                if (isCurrentReferenceImage || isHovered)
-                  Padding(
-                    padding: const EdgeInsets.only(left: Sizes.p16),
-                    child: Tooltip(
-                      message: context.l10n.toggleVisibility,
-                      child: InkWell(
-                        onTap: () {
-                          if (isCurrentReferenceImage) {
-                            selectedReferenceImages.value =
-                                selectedReferenceImages.value
-                                    .where((e) => e != widget.file.id)
-                                    .toList();
-                          } else {
-                            selectedReferenceImages.value = [
-                              ...selectedReferenceImages.value,
-                              widget.file.id
-                            ];
-                          }
-                        },
-                        child: const Icon(
-                          CupertinoIcons.eye_solid,
-                          size: Sizes.p16,
-                          // color: Colors.grey,
+      return CopyableItemWrapper<FlitesImage>(
+        itemData: widget.file,
+        child: MouseRegion(
+          onEnter: (event) => isHoveredState.value = true,
+          onExit: (event) => isHoveredState.value = false,
+          child: Container(
+            margin: const EdgeInsets.symmetric(
+              vertical: Sizes.p2,
+              horizontal: Sizes.p8,
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: Sizes.p24,
+              vertical: Sizes.p8,
+            ),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(Sizes.p8),
+              color: isCurrentlySelected
+                  ? context.colors.surface
+                  : isHovered
+                      ? context.colors.surface
+                      : Colors.transparent,
+            ),
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                SelectedImageState.setSelectedImage(widget.file.id);
+              },
+              child: Row(
+                children: [
+                  SvgUtils.isSvg(widget.file.image)
+                      ? SvgPicture.memory(
+                          widget.file.image,
+                          fit: BoxFit.contain,
+                          width: Sizes.p24,
+                          height: Sizes.p24,
+                        )
+                      : Image.memory(
+                          widget.file.image,
+                          fit: BoxFit.contain,
+                          width: Sizes.p24,
+                          height: Sizes.p24,
+                        ),
+                  if (widget.file.displayName != null)
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          left: Sizes.p24,
+                          right: Sizes.p16,
+                        ),
+                        child: Text(
+                          widget.file.displayName!,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                     ),
-                  ),
-              ],
+                  if (isHovered)
+                    Padding(
+                      padding: const EdgeInsets.only(left: Sizes.p16),
+                      child: Tooltip(
+                        message: context.l10n.delete,
+                        child: InkWell(
+                          onTap: () {
+                            SourceFilesState.deleteImage(widget.file.id);
+                          },
+                          child: const Icon(Icons.delete, size: Sizes.p16),
+                        ),
+                      ),
+                    ),
+                  if (isCurrentReferenceImage || isHovered)
+                    Padding(
+                      padding: const EdgeInsets.only(left: Sizes.p16),
+                      child: Tooltip(
+                        message: context.l10n.toggleVisibility,
+                        child: InkWell(
+                          onTap: () {
+                            if (isCurrentReferenceImage) {
+                              selectedReferenceImages.value =
+                                  selectedReferenceImages.value
+                                      .where((e) => e != widget.file.id)
+                                      .toList();
+                            } else {
+                              selectedReferenceImages.value = [
+                                ...selectedReferenceImages.value,
+                                widget.file.id
+                              ];
+                            }
+                          },
+                          child: const Icon(
+                            CupertinoIcons.eye_solid,
+                            size: Sizes.p16,
+                            // color: Colors.grey,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
             ),
           ),
         ),

--- a/apps/flites/lib/widgets/right_click_menu/copyable_item_wrapper.dart
+++ b/apps/flites/lib/widgets/right_click_menu/copyable_item_wrapper.dart
@@ -5,8 +5,8 @@ import 'package:flites/widgets/right_click_menu/right_click_menu_handler.dart';
 /// A widget that wraps around a ListItem and provides it's
 /// data to the [RightClickMenuHandler] to show a context menu
 /// when the item is right-clicked.
-class CopyableItemWrapper<T> extends StatelessWidget {
-  final T itemData;
+class CopyableItemWrapper extends StatelessWidget {
+  final FlitesImage itemData;
   final Widget child;
 
   const CopyableItemWrapper({
@@ -24,7 +24,7 @@ class CopyableItemWrapper<T> extends StatelessWidget {
 
         handlerState?.showContextMenu(
           details,
-          [itemData] as List<FlitesImage?>,
+          [itemData],
         );
       },
       child: child,

--- a/apps/flites/lib/widgets/right_click_menu/copyable_item_wrapper.dart
+++ b/apps/flites/lib/widgets/right_click_menu/copyable_item_wrapper.dart
@@ -1,0 +1,33 @@
+import 'package:flites/types/flites_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flites/widgets/right_click_menu/right_click_menu_handler.dart';
+
+/// A widget that wraps around a ListItem and provides it's
+/// data to the [RightClickMenuHandler] to show a context menu
+/// when the item is right-clicked.
+class CopyableItemWrapper<T> extends StatelessWidget {
+  final T itemData;
+  final Widget child;
+
+  const CopyableItemWrapper({
+    super.key,
+    required this.itemData,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onSecondaryTapDown: (details) {
+        final handlerState =
+            context.findAncestorStateOfType<RightClickMenuHandlerState>();
+
+        handlerState?.showContextMenu(
+          details,
+          [itemData] as List<FlitesImage?>,
+        );
+      },
+      child: child,
+    );
+  }
+}

--- a/apps/flites/lib/widgets/right_click_menu/right_click_menu_handler.dart
+++ b/apps/flites/lib/widgets/right_click_menu/right_click_menu_handler.dart
@@ -28,19 +28,20 @@ class RightClickMenuHandler extends StatefulWidget {
 /// show the context menu and pass the item data to it.
 class RightClickMenuHandlerState extends State<RightClickMenuHandler> {
   OverlayEntry? _overlayEntry;
-  bool isPasteEnabled = false;
-  bool isCopyEnabled = false;
 
   void showContextMenu(
     TapDownDetails details, [
     List<FlitesImage?> contextData = const [],
   ]) {
+    bool isCopyEnabled = false;
+    bool isPasteEnabled = false;
+
     if (_overlayEntry != null && _overlayEntry!.mounted) {
       _overlayEntry!.remove();
       _overlayEntry = null;
     }
 
-    bool isPasteEnabled = clipboardService.hasData;
+    isPasteEnabled = clipboardService.hasData;
 
     if (contextData.isNotEmpty) {
       isCopyEnabled = true;

--- a/apps/flites/lib/widgets/right_click_menu/right_click_menu_handler.dart
+++ b/apps/flites/lib/widgets/right_click_menu/right_click_menu_handler.dart
@@ -1,0 +1,136 @@
+import 'package:flites/main.dart';
+import 'package:flites/services/clipboard_service.dart';
+import 'package:flites/types/flites_image.dart';
+import 'package:flites/widgets/right_click_menu/right_click_menu_item.dart';
+import 'package:flutter/material.dart';
+
+/// A widget that wraps around the whole application to handle
+/// right-click context menus.
+/// It listens for right-click events and shows a context menu with the following options:
+/// - Copy: Copies the selected image to the clipboard.
+/// - Paste: Pastes the image from the clipboard to the currently opened animation.
+/// The context menu is shown at the position of the right-click event.
+/// The context menu is removed when the user clicks outside of it.
+class RightClickMenuHandler extends StatefulWidget {
+  const RightClickMenuHandler({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  RightClickMenuHandlerState createState() => RightClickMenuHandlerState();
+}
+
+/// The state of the [RightClickMenuHandler] widget.
+/// We access the state via the [context] in [CopyableItemWrapper] to
+/// show the context menu and pass the item data to it.
+class RightClickMenuHandlerState extends State<RightClickMenuHandler> {
+  OverlayEntry? _overlayEntry;
+  bool isPasteEnabled = false;
+  bool isCopyEnabled = false;
+
+  void showContextMenu(
+    TapDownDetails details, [
+    List<FlitesImage?> contextData = const [],
+  ]) {
+    if (_overlayEntry != null && _overlayEntry!.mounted) {
+      _overlayEntry!.remove();
+      _overlayEntry = null;
+    }
+
+    bool isPasteEnabled = clipboardService.hasData;
+
+    if (contextData.isNotEmpty) {
+      isCopyEnabled = true;
+    } else {
+      isCopyEnabled = false;
+    }
+
+    _overlayEntry = OverlayEntry(
+      builder: (context) => Stack(
+        children: [
+          // Transparent background to capture taps outside the menu
+          // and remove the overlay when tapped
+          // This is a full-screen transparent container
+          Positioned.fill(
+            child: GestureDetector(
+              onTap: _removeOverlay,
+              onSecondaryTapDown: (details) => showContextMenu(details),
+              behavior: HitTestBehavior.opaque,
+            ),
+          ),
+          // The context menu itself
+          // Positioned at the location of the right-click event
+          // with a small offset to avoid being directly under the cursor
+          Positioned(
+            left: details.globalPosition.dx,
+            top: details.globalPosition.dy,
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                width: 150,
+                decoration: BoxDecoration(
+                  color: context.colors.surface,
+                  borderRadius: BorderRadius.circular(8.0),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.2),
+                      blurRadius: 4.0,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RightClickMenuItem(
+                      title: 'Copy',
+                      enabled: isCopyEnabled,
+                      onTap: () {
+                        if (contextData.isNotEmpty) {
+                          clipboardService.copyImage(
+                              contextData.whereType<FlitesImage>().toList());
+                        }
+                        isCopyEnabled = false;
+                        _removeOverlay();
+                      },
+                    ),
+                    RightClickMenuItem(
+                      title: 'Paste',
+                      enabled: isPasteEnabled,
+                      onTap: () {
+                        clipboardService.pasteImage();
+                        _removeOverlay();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    Overlay.of(context).insert(_overlayEntry!);
+  }
+
+  void _removeOverlay() {
+    if (_overlayEntry != null && _overlayEntry!.mounted) {
+      _overlayEntry!.remove();
+      _overlayEntry = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onSecondaryTapDown: (details) => showContextMenu(
+        details,
+      ),
+      child: widget.child,
+    );
+  }
+}

--- a/apps/flites/lib/widgets/right_click_menu/right_click_menu_item.dart
+++ b/apps/flites/lib/widgets/right_click_menu/right_click_menu_item.dart
@@ -1,0 +1,54 @@
+// Custom widget for menu items with hover effect
+import 'package:flites/constants/app_sizes.dart';
+import 'package:flites/main.dart';
+import 'package:flutter/material.dart';
+
+class RightClickMenuItem extends StatefulWidget {
+  final String title;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  const RightClickMenuItem({
+    super.key,
+    required this.title,
+    required this.onTap,
+    this.enabled = true,
+  });
+
+  @override
+  RightClickMenuItemState createState() => RightClickMenuItemState();
+}
+
+class RightClickMenuItemState extends State<RightClickMenuItem> {
+  bool _isHovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (event) => setState(() => _isHovering = true),
+      onExit: (event) => setState(() => _isHovering = false),
+      child: GestureDetector(
+        onTap: widget.enabled ? widget.onTap : null,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(Sizes.p8),
+            color: _isHovering ? context.colors.primary : Colors.transparent,
+          ),
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          child: Text(
+            widget.title,
+            style: TextStyle(
+              color: !widget.enabled
+                  ? context.colors.onSurface.withAlpha(100)
+                  : _isHovering
+                      ? Colors.white
+                      : context.colors.onSurface,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR tries to close #75. It adds a `ClipboardService` class which exposes a `copy`  and `paste` method. Also a `RightClickMenuHandler` that wrapps the whole app and listens to right clicks and displays a context menu. 

![Selection_128](https://github.com/user-attachments/assets/055ae6a9-bcf0-4459-8a20-ad87aec254eb)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added right-click context menu support throughout the app, allowing users to copy and paste images via a contextual menu.
  - Introduced clipboard functionality for managing copied images and enabling pasting into the current selection.
  - Implemented visual feedback for menu items, including hover effects and enabled/disabled states.

- **Improvements**
  - Enhanced image item interactions by enabling right-click actions directly on image file entries.
  - Added duplication of images when pasting to preserve original data.
  - Wrapped main overview screen and file items with right-click menu handlers for consistent context menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->