### PR TITLE
fix: Reorder functionality of ProjectFileListVertical

### DIFF
--- a/apps/flites/lib/states/source_files_state.dart
+++ b/apps/flites/lib/states/source_files_state.dart
@@ -114,18 +114,28 @@ class SourceFilesState {
       newIndex -= 1;
     }
 
-    final currentImages = List<FlitesImage>.from(
-        projectSourceFiles.value.rows[selectedImageRow.value].images);
+    final currentState = projectSourceFiles.value;
+    final currentRowIndex = selectedImageRow.value;
 
+    // Create a mutable copy of the current row's images
+    final currentImages =
+        List<FlitesImage>.from(currentState.rows[currentRowIndex].images);
+
+    // Perform the reordering on the copied list
     final item = currentImages.removeAt(oldIndex);
-
     currentImages.insert(newIndex, item);
 
-    // TODO(jaco): this doesn't work
-    projectSourceFiles.value.rows[selectedImageRow.value] =
-        projectSourceFiles.value.rows[selectedImageRow.value].copyWith(
+    // Create a new copy of the current row with the updated images
+    final updatedRow = currentState.rows[currentRowIndex].copyWith(
       images: currentImages,
     );
+
+    // Create a new copy of the entire rows list
+    final updatedRows = List<FlitesImageRow>.from(currentState.rows);
+    updatedRows[currentRowIndex] = updatedRow;
+
+    // Update the projectSourceFiles signal with a new state containing the new rows list
+    _projectSourceFiles.value = currentState.copyWith(rows: updatedRows);
   }
 
   static void deleteImage(String id) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR restructures reorderImages to update the state when an image is reordered via drag and drop 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability and consistency of image reordering within rows, ensuring smoother updates when rearranging images. No changes to how you interact with the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->