### PR TITLE
feat: include export information when generating images

### DIFF
--- a/apps/flites/lib/types/exported_sprite_image.dart
+++ b/apps/flites/lib/types/exported_sprite_image.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import 'exported_sprite_row_info.dart';
+
+/// An abstract class that represents an exported sprite image.
+///
+/// In addition to the image itself, each implementation of this class holds
+/// additional information regarding the exported sprite.
+sealed class ExportedSpriteImage {
+  final Uint8List image;
+
+  ExportedSpriteImage({required this.image});
+}
+
+/// This class is used when exporting a sprite sheet that is tiled, ie. with a
+/// fixed frame size.
+class ExportedSprilteSheetTiled extends ExportedSpriteImage {
+  /// The size of each tile in the sprite sheet.
+  final Size tileSize;
+
+  ExportedSprilteSheetTiled({required super.image, required this.tileSize});
+}
+
+/// This class is used when exporting a sprite sheet that is not tiled, ie. with
+/// a variable frame size for each contained animation.
+class ExportedSpriteSheet extends ExportedSpriteImage {
+  /// The rows of animations contained in the sprite sheet.
+  final List<ExportedSpriteRowInfo> rowInformations;
+
+  ExportedSpriteSheet({required super.image, required this.rowInformations});
+}
+
+/// This class is used when exporting a single animation.
+class ExportedSpriteRow extends ExportedSpriteImage {
+  /// The information of the animation contained in the image.
+  final ExportedSpriteRowInfo rowInfo;
+
+  ExportedSpriteRow({required super.image, required this.rowInfo});
+}

--- a/apps/flites/lib/types/exported_sprite_row_info.dart
+++ b/apps/flites/lib/types/exported_sprite_row_info.dart
@@ -1,0 +1,42 @@
+import 'dart:ui';
+
+/// A class that represents the information of a single row of frames (an
+/// animation) in an exported image.
+///
+/// This class is used by itself when exporting a single animation, or as a
+/// [List<ExportedSpriteRowInfo] for sprite sheets.
+class ExportedSpriteRowInfo {
+  // The name of the row or animation
+  final String name;
+
+  // The total width of the exported image
+  final int totalWidth;
+
+  // The total height of the exported image
+  final int totalHeight;
+
+  // The offset from the top of the sprite sheet to this animation
+  final int offsetFromTop;
+
+  // The number of frames inside this animation
+  final int numberOfFrames;
+
+  // The calculated size of each frame in this animation
+  Size get frameSize =>
+      Size(totalWidth / numberOfFrames, totalHeight.toDouble());
+
+  ExportedSpriteRowInfo.inSpriteSheet({
+    required this.name,
+    required this.totalWidth,
+    required this.totalHeight,
+    required this.offsetFromTop,
+    required this.numberOfFrames,
+  });
+
+  ExportedSpriteRowInfo.asSingleRow({
+    required this.name,
+    required this.totalWidth,
+    required this.totalHeight,
+    required this.numberOfFrames,
+  }) : offsetFromTop = 0;
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Includes data objects that carry additional information when exporting images, such that code generation or other parts of the app can use it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Sprite export now provides detailed metadata alongside image files, including animation names, frame sizes, and row information.
	- Exported sprite sheets and rows now return structured objects that bundle both image data and descriptive metadata.
- **Improvements**
	- Enhanced sprite export workflows for both raster and SVG formats, making it easier to manage and utilize exported assets with their metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->