### PR TITLE
feat: right click menu add delete button, fix position on screen edge…

### DIFF
--- a/apps/flites/lib/types/secondary_click_context_data.dart
+++ b/apps/flites/lib/types/secondary_click_context_data.dart
@@ -1,0 +1,11 @@
+import 'package:flites/types/flites_image.dart';
+
+class SecondaryClickContextData {
+  final void Function()? onDelete;
+  final List<FlitesImage?> copyableData;
+
+  const SecondaryClickContextData({
+    this.onDelete,
+    this.copyableData = const [],
+  });
+}

--- a/apps/flites/lib/utils/positioning_utils.dart
+++ b/apps/flites/lib/utils/positioning_utils.dart
@@ -1,0 +1,26 @@
+import 'dart:math';
+
+import 'package:flites/constants/app_sizes.dart';
+import 'package:flutter/material.dart';
+
+class PositioningUtils {
+  /// Returns an offset measured from the top left corner of the screen where the
+  /// entire overlay will be visible
+  static Offset adjustOverlayOffsetToBeVisible({
+    required Offset clickedPosition,
+    required Size overlaySize,
+    required Size screenSize,
+  }) {
+    final left = min(
+      clickedPosition.dx,
+      screenSize.width - overlaySize.width - Sizes.p16,
+    );
+
+    final top = min(
+      clickedPosition.dy,
+      screenSize.height - overlaySize.height - Sizes.p16,
+    );
+
+    return Offset(left, top);
+  }
+}

--- a/apps/flites/lib/widgets/image_map_widgets/image_map_header.dart
+++ b/apps/flites/lib/widgets/image_map_widgets/image_map_header.dart
@@ -3,10 +3,12 @@ import 'package:flites/main.dart';
 import 'package:flites/services/project_saving_service.dart';
 import 'package:flites/states/selected_image_row_state.dart';
 import 'package:flites/states/source_files_state.dart';
+import 'package:flites/types/secondary_click_context_data.dart';
 import 'package:flites/utils/generate_sprite.dart';
 import 'package:flites/utils/generate_svg_sprite.dart';
 import 'package:flites/utils/svg_utils.dart';
 import 'package:flites/widgets/logo/logo_widget.dart';
+import 'package:flites/widgets/right_click_menu/right_clickable_item_wrapper.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -71,16 +73,23 @@ class ImageMapHeader extends StatelessWidget {
                           itemBuilder: (c, i) {
                             final isSelected = selectedAnimation == i;
 
-                            return AnimationRowTabWrapper(
-                              onPressed: () {
-                                SelectedImageRowState.setSelectedImageRow(i);
-                              },
-                              isSelected: isSelected,
-                              child: AnimationRowTabName(
+                            return RightClickableItemWrapper(
+                              contextData: SecondaryClickContextData(
+                                onDelete: () {
+                                  SourceFilesState.deleteImageRow(i);
+                                },
+                              ),
+                              child: AnimationRowTabWrapper(
+                                onPressed: () {
+                                  SelectedImageRowState.setSelectedImageRow(i);
+                                },
                                 isSelected: isSelected,
-                                name: images.rows[i].name,
-                                index: i,
-                                key: ValueKey(images.rows[i].hashCode),
+                                child: AnimationRowTabName(
+                                  isSelected: isSelected,
+                                  name: images.rows[i].name,
+                                  index: i,
+                                  key: ValueKey(images.rows[i].hashCode),
+                                ),
                               ),
                             );
                           },

--- a/apps/flites/lib/widgets/project_file_list/file_item.dart
+++ b/apps/flites/lib/widgets/project_file_list/file_item.dart
@@ -4,8 +4,9 @@ import 'package:flites/states/open_project.dart';
 import 'package:flites/states/selected_image_state.dart';
 import 'package:flites/states/source_files_state.dart';
 import 'package:flites/types/flites_image.dart';
+import 'package:flites/types/secondary_click_context_data.dart';
 import 'package:flites/utils/svg_utils.dart';
-import 'package:flites/widgets/right_click_menu/copyable_item_wrapper.dart';
+import 'package:flites/widgets/right_click_menu/right_clickable_item_wrapper.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -33,8 +34,13 @@ class _FileItemState extends State<FileItem> {
       final isCurrentReferenceImage =
           selectedReferenceImages.value.contains(widget.file.id);
 
-      return CopyableItemWrapper(
-        itemData: widget.file,
+      return RightClickableItemWrapper(
+        contextData: SecondaryClickContextData(
+          copyableData: [widget.file],
+          onDelete: () {
+            SourceFilesState.deleteImage(widget.file.id);
+          },
+        ),
         child: MouseRegion(
           onEnter: (event) => isHoveredState.value = true,
           onExit: (event) => isHoveredState.value = false,

--- a/apps/flites/lib/widgets/right_click_menu/right_click_menu_item.dart
+++ b/apps/flites/lib/widgets/right_click_menu/right_click_menu_item.dart
@@ -3,6 +3,8 @@ import 'package:flites/constants/app_sizes.dart';
 import 'package:flites/main.dart';
 import 'package:flutter/material.dart';
 
+const rightClickMenuItemHeight = Sizes.p32;
+
 class RightClickMenuItem extends StatefulWidget {
   final String title;
   final VoidCallback onTap;
@@ -30,12 +32,14 @@ class RightClickMenuItemState extends State<RightClickMenuItem> {
       child: GestureDetector(
         onTap: widget.enabled ? widget.onTap : null,
         child: Container(
+          alignment: Alignment.centerLeft,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(Sizes.p8),
             color: _isHovering ? context.colors.primary : Colors.transparent,
           ),
           width: double.infinity,
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          height: rightClickMenuItemHeight,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Text(
             widget.title,
             style: TextStyle(

--- a/apps/flites/lib/widgets/right_click_menu/right_clickable_item_wrapper.dart
+++ b/apps/flites/lib/widgets/right_click_menu/right_clickable_item_wrapper.dart
@@ -1,18 +1,18 @@
-import 'package:flites/types/flites_image.dart';
+import 'package:flites/types/secondary_click_context_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flites/widgets/right_click_menu/right_click_menu_handler.dart';
 
 /// A widget that wraps around a ListItem and provides it's
 /// data to the [RightClickMenuHandler] to show a context menu
 /// when the item is right-clicked.
-class CopyableItemWrapper extends StatelessWidget {
-  final FlitesImage itemData;
+class RightClickableItemWrapper extends StatelessWidget {
   final Widget child;
+  final SecondaryClickContextData contextData;
 
-  const CopyableItemWrapper({
+  const RightClickableItemWrapper({
     super.key,
-    required this.itemData,
     required this.child,
+    required this.contextData,
   });
 
   @override
@@ -24,7 +24,7 @@ class CopyableItemWrapper extends StatelessWidget {
 
         handlerState?.showContextMenu(
           details,
-          [itemData],
+          contextData: contextData,
         );
       },
       child: child,


### PR DESCRIPTION
…, make more abstract to be used anywhere on screen

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Improve right click menu.

Adds a delete button.
Makes the data abstract so it can be used anywhere on the screen.
Fix the position on the right and bottom border of the screen

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added right-click context menus to file items and animation row tabs, enabling actions such as copy and delete directly from the menu.
  - Introduced a "Delete" option in right-click menus where applicable.

- **Improvements**
  - Context menus are now positioned to remain fully visible on the screen.
  - Menu item layout improved for consistent height and left-aligned content.

- **Refactor**
  - Unified and generalized right-click handling across widgets for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->