### PR TITLE
fix: Correct AnimationState Name to camelCase

### DIFF
--- a/apps/flites/lib/feature_kits/code_wizards/flutter_flame/flutter_flame_code_generator.dart
+++ b/apps/flites/lib/feature_kits/code_wizards/flutter_flame/flutter_flame_code_generator.dart
@@ -104,7 +104,7 @@ class FlutterFlameCodeGenerator {
         : spriteSheet.rowInformations[0];
 
     return stub.replaceAll('{{alternativeAnimationState}}',
-        '{{SpriteName}}SpriteState.${state.name}');
+        '{{SpriteName}}SpriteState.${Casing.camelCase(state.name)}');
   }
 
   /// Generates the Dart code string for the _hitboxVertices map.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Description

<!--- Describe your changes in detail -->
This is just a small fix, as the `AnimationState.idle` was generated as `AnimationState.Idle` (with a capital I)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Alternative animation state names are now consistently formatted in camelCase in generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->