### PR TITLE
refactor: change text color of image_map_header to onPrimary

### DIFF
--- a/apps/flites/lib/widgets/image_map_widgets/image_map_header.dart
+++ b/apps/flites/lib/widgets/image_map_widgets/image_map_header.dart
@@ -124,8 +124,9 @@ class ImageMapHeader extends StatelessWidget {
                     );
                   },
                   tooltip: 'New Sprite',
-                  child: const Icon(
+                  child: Icon(
                     Icons.add,
+                    color: context.colors.onPrimary,
                     size: Sizes.p16,
                   ),
                 ),
@@ -165,7 +166,12 @@ class ImageMapHeader extends StatelessWidget {
               bottomRight: Radius.circular(Sizes.p8),
             ),
             tooltip: context.l10n.exportSprite,
-            child: Text(context.l10n.exportSprite),
+            child: Text(
+              context.l10n.exportSprite,
+              style: TextStyle(
+                color: context.colors.onPrimary,
+              ),
+            ),
           ),
         ],
       ),
@@ -223,7 +229,7 @@ class _AnimationRowTabNameState extends State<AnimationRowTabName> {
               maxLines: 1,
               style: TextStyle(
                 fontSize: 14,
-                color: context.colors.onSurface,
+                color: context.colors.onPrimary,
               ),
               onSubmitted: (value) {
                 SourceFilesState.renameImageRow(value);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Description

<!--- Describe your changes in detail -->
This PR changes the text color within `ImageMapHeader` to `onPrimary` as it should be white in both dark and light mode as per styleguide.

![Selection_146](https://github.com/user-attachments/assets/bae86efd-122c-4d95-b5d9-643335c3fa77)
![Selection_145](https://github.com/user-attachments/assets/a46d4080-2e96-48e3-9941-7ad44e3d163a)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated UI elements to use consistent color styling, applying the theme's primary text color to icons and text in header and tab components for improved visual coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->