### PR TITLE
fix(canvas): remove false onTap deselecting frame on canvas tab

### DIFF
--- a/apps/flites/lib/feature_kits/tools/canvas_helpers/canvas_gesture_handler.dart
+++ b/apps/flites/lib/feature_kits/tools/canvas_helpers/canvas_gesture_handler.dart
@@ -34,7 +34,6 @@ class _CanvasGestureHandler extends StatelessWidget {
           },
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onTap: SelectedImageState.clearSelection,
             onPanStart: (details) {
               _isGrabbing.value = true;
             },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Description

<!--- Describe your changes in detail -->
This PR removes the call to deselect the currrently selected frame when tapping on the canvas. 



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where tapping the canvas would unintentionally clear the current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->